### PR TITLE
Improve inliner

### DIFF
--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/nodes/GraphDecoder.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/nodes/GraphDecoder.java
@@ -73,6 +73,7 @@ import jdk.graal.compiler.nodes.spi.Canonicalizable;
 import jdk.graal.compiler.nodes.spi.CanonicalizerTool;
 import jdk.graal.compiler.options.OptionValues;
 import jdk.graal.compiler.replacements.nodes.MethodHandleWithExceptionNode;
+import jdk.graal.compiler.util.EconomicHashMap;
 import jdk.graal.compiler.util.IntArrayBuilder;
 import jdk.vm.ci.code.Architecture;
 import jdk.vm.ci.meta.Assumptions;
@@ -149,6 +150,9 @@ public class GraphDecoder {
          * inlining log. {@code null} if the inlining log is not being decoded.
          */
         public InliningLogCodec.InliningLogDecoder inliningLogDecoder;
+        public int benefit = 0;
+        public int invokeCount = 0;
+        public EconomicHashMap<ResolvedJavaMethod, Integer> newCallees = new EconomicHashMap<>(4);
 
         @SuppressWarnings("unchecked")
         protected MethodScope(LoopScope callerLoopScope, StructuredGraph graph, EncodedGraph encodedGraph, LoopExplosionPlugin.LoopExplosionKind loopExplosion) {
@@ -1159,6 +1163,7 @@ public class GraphDecoder {
             } else if (node instanceof Invoke) {
                 InvokeData invokeData = readInvokeData(methodScope, nodeOrderId, (Invoke) node);
                 resultScope = handleInvoke(methodScope, loopScope, invokeData);
+                methodScope.invokeCount++;
             } else if (node instanceof MethodHandleWithExceptionNode methodHandle) {
                 InvokableData<MethodHandleWithExceptionNode> invokableData = readInvokableData(methodScope, nodeOrderId, methodHandle);
                 resultScope = handleMethodHandle(methodScope, loopScope, invokableData);

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/replacements/PEGraphDecoder.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/replacements/PEGraphDecoder.java
@@ -34,8 +34,10 @@ import static jdk.graal.compiler.nodeinfo.NodeSize.SIZE_0;
 import static jdk.graal.compiler.nodeinfo.NodeSize.SIZE_IGNORED;
 
 import java.net.URI;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.Formatter;
 import java.util.List;
 import java.util.Map;
@@ -183,7 +185,7 @@ public abstract class PEGraphDecoder extends SimplifyingGraphDecoder {
         public static final OptionKey<Boolean> FailedLoopExplosionIsFatal = new OptionKey<>(false);
     }
 
-    protected class PEMethodScope extends MethodScope {
+    public class PEMethodScope extends MethodScope {
         /** The state of the caller method. Only non-null during method inlining. */
         public final PEMethodScope caller;
         public final ResolvedJavaMethod method;
@@ -343,7 +345,7 @@ public abstract class PEGraphDecoder extends SimplifyingGraphDecoder {
         }
     }
 
-    protected class PENonAppendGraphBuilderContext extends CoreProvidersDelegate implements GraphBuilderContext {
+    public class PENonAppendGraphBuilderContext extends CoreProvidersDelegate implements GraphBuilderContext {
         public final PEMethodScope methodScope;
         protected final Invoke invoke;
 
@@ -1440,6 +1442,65 @@ public abstract class PEGraphDecoder extends SimplifyingGraphDecoder {
         if (methodScope.optimizationLog != null) {
             assert inlineScope.optimizationLog != null : "all inlinees should have an optimization log if the root requires it";
             methodScope.optimizationLog.inline(inlineScope.optimizationLog, false, null);
+        }
+    }
+
+    /**
+     * Kill fixed nodes of structured control flow. Not as generic, but faster, than
+     * {@link GraphUtil#killCFG}.
+     *
+     * We cannot kill unused floating nodes at this point, because we are still in the middle of
+     * decoding caller graphs, so floating nodes of the caller that have no usage yet can get used
+     * when decoding of the caller continues. Unused floating nodes are cleaned up by the next run
+     * of the CanonicalizerPhase.
+     */
+    protected void killControlFlowNodes(PEMethodScope inlineScope, FixedNode start) {
+        Deque<Node> workList = null;
+        Node cur = start;
+        for (int i = 0; i < 1000000; i++) {
+            assert !cur.isDeleted() : cur;
+            assert graph.isNew(inlineScope.methodStartMark, cur) : cur;
+
+            Node next = null;
+            if (cur instanceof FixedWithNextNode) {
+                next = ((FixedWithNextNode) cur).next();
+            } else if (cur instanceof ControlSplitNode) {
+                for (Node successor : cur.successors()) {
+                    if (next == null) {
+                        next = successor;
+                    } else {
+                        if (workList == null) {
+                            workList = new ArrayDeque<>();
+                        }
+                        workList.push(successor);
+                    }
+                }
+            } else if (cur instanceof AbstractEndNode) {
+                next = ((AbstractEndNode) cur).merge();
+            } else if (cur instanceof ControlSinkNode) {
+                /* End of this control flow path. */
+            } else {
+                throw GraalError.shouldNotReachHereUnexpectedValue(cur); // ExcludeFromJacocoGeneratedReport
+            }
+
+            if (cur instanceof AbstractMergeNode) {
+                for (ValueNode phi : ((AbstractMergeNode) cur).phis().snapshot()) {
+                    phi.replaceAtUsages(null);
+                    phi.safeDelete();
+                }
+            }
+
+            cur.replaceAtPredecessor(null);
+            cur.replaceAtUsages(null);
+            cur.safeDelete();
+
+            if (next != null) {
+                cur = next;
+            } else if (workList != null && !workList.isEmpty()) {
+                cur = workList.pop();
+            } else {
+                return;
+            }
         }
     }
 

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/phases/InlineBeforeAnalysisGraphDecoder.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/phases/InlineBeforeAnalysisGraphDecoder.java
@@ -26,8 +26,6 @@ package com.oracle.graal.pointsto.phases;
 
 import static com.oracle.graal.pointsto.phases.InlineBeforeAnalysisGraphDecoder.InlineBeforeAnalysisMethodScope.recordInlined;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.graalvm.collections.EconomicSet;
@@ -39,16 +37,10 @@ import com.oracle.graal.pointsto.meta.HostedProviders;
 import com.oracle.graal.pointsto.phases.InlineBeforeAnalysisPolicy.AbstractPolicyScope;
 
 import jdk.graal.compiler.bytecode.BytecodeProvider;
-import jdk.graal.compiler.debug.GraalError;
 import jdk.graal.compiler.graph.Node;
 import jdk.graal.compiler.graph.NodeSourcePosition;
-import jdk.graal.compiler.nodes.AbstractEndNode;
-import jdk.graal.compiler.nodes.AbstractMergeNode;
 import jdk.graal.compiler.nodes.CallTargetNode;
-import jdk.graal.compiler.nodes.ControlSinkNode;
-import jdk.graal.compiler.nodes.ControlSplitNode;
 import jdk.graal.compiler.nodes.EncodedGraph;
-import jdk.graal.compiler.nodes.FixedNode;
 import jdk.graal.compiler.nodes.FixedWithNextNode;
 import jdk.graal.compiler.nodes.InvokeWithExceptionNode;
 import jdk.graal.compiler.nodes.StructuredGraph;
@@ -58,7 +50,6 @@ import jdk.graal.compiler.nodes.graphbuilderconf.InlineInvokePlugin;
 import jdk.graal.compiler.nodes.graphbuilderconf.InvocationPlugin;
 import jdk.graal.compiler.nodes.graphbuilderconf.LoopExplosionPlugin;
 import jdk.graal.compiler.nodes.java.MethodCallTargetNode;
-import jdk.graal.compiler.nodes.util.GraphUtil;
 import jdk.graal.compiler.replacements.PEGraphDecoder;
 import jdk.graal.compiler.replacements.nodes.MethodHandleWithExceptionNode;
 import jdk.graal.compiler.replacements.nodes.ResolvedMethodHandleCallTargetNode;
@@ -357,65 +348,6 @@ public class InlineBeforeAnalysisGraphDecoder extends PEGraphDecoder {
         ((AnalysisMethod) invokeData.callTarget.targetMethod()).registerAsInlined(reason);
 
         super.finishInlining(inlineScope);
-    }
-
-    /**
-     * Kill fixed nodes of structured control flow. Not as generic, but faster, than
-     * {@link GraphUtil#killCFG}.
-     *
-     * We cannot kill unused floating nodes at this point, because we are still in the middle of
-     * decoding caller graphs, so floating nodes of the caller that have no usage yet can get used
-     * when decoding of the caller continues. Unused floating nodes are cleaned up by the next run
-     * of the CanonicalizerPhase.
-     */
-    private void killControlFlowNodes(PEMethodScope inlineScope, FixedNode start) {
-        Deque<Node> workList = null;
-        Node cur = start;
-        while (true) {
-            assert !cur.isDeleted() : cur;
-            assert graph.isNew(inlineScope.methodStartMark, cur) : cur;
-
-            Node next = null;
-            if (cur instanceof FixedWithNextNode) {
-                next = ((FixedWithNextNode) cur).next();
-            } else if (cur instanceof ControlSplitNode) {
-                for (Node successor : cur.successors()) {
-                    if (next == null) {
-                        next = successor;
-                    } else {
-                        if (workList == null) {
-                            workList = new ArrayDeque<>();
-                        }
-                        workList.push(successor);
-                    }
-                }
-            } else if (cur instanceof AbstractEndNode) {
-                next = ((AbstractEndNode) cur).merge();
-            } else if (cur instanceof ControlSinkNode) {
-                /* End of this control flow path. */
-            } else {
-                throw GraalError.shouldNotReachHereUnexpectedValue(cur); // ExcludeFromJacocoGeneratedReport
-            }
-
-            if (cur instanceof AbstractMergeNode) {
-                for (ValueNode phi : ((AbstractMergeNode) cur).phis().snapshot()) {
-                    phi.replaceAtUsages(null);
-                    phi.safeDelete();
-                }
-            }
-
-            cur.replaceAtPredecessor(null);
-            cur.replaceAtUsages(null);
-            cur.safeDelete();
-
-            if (next != null) {
-                cur = next;
-            } else if (workList != null && !workList.isEmpty()) {
-                cur = workList.pop();
-            } else {
-                return;
-            }
-        }
     }
 
     /**

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -915,14 +915,14 @@ public class SubstrateOptions {
     @Option(help = "file:doc-files/NeverInlineHelp.txt", type = OptionType.Debug)//
     public static final HostedOptionKey<AccumulatingLocatableMultiOptionValue.Strings> NeverInline = new HostedOptionKey<>(AccumulatingLocatableMultiOptionValue.Strings.build());
 
-    @Option(help = "Maximum number of nodes in a method so that it is considered trivial.")//
-    public static final HostedOptionKey<Integer> MaxNodesInTrivialMethod = new HostedOptionKey<>(20);
+    @Option(help = "Maximum size of a method so that it is considered trivial.")//
+    public static final HostedOptionKey<Integer> MaxTrivialMethodSize = new HostedOptionKey<>(55);
 
     @Option(help = "Maximum number of invokes in a method so that it is considered trivial (for testing only).")//
     public static final HostedOptionKey<Integer> MaxInvokesInTrivialMethod = new HostedOptionKey<>(1);
 
-    @Option(help = "Maximum number of nodes in a method so that it is considered trivial, if it does not have any invokes.")//
-    public static final HostedOptionKey<Integer> MaxNodesInTrivialLeafMethod = new HostedOptionKey<>(40);
+    @Option(help = "Maximum size of a method so that it is considered trivial, if it does not have any invokes.")//
+    public static final HostedOptionKey<Integer> MaxTrivialLeafMethodSize = new HostedOptionKey<>(128);
 
     @Option(help = "The maximum number of nodes in a graph allowed after trivial inlining.")//
     public static final HostedOptionKey<Integer> MaxNodesAfterTrivialInlining = new HostedOptionKey<>(Integer.MAX_VALUE);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CalleeInfo.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CalleeInfo.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2025, IBM Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.hosted.code;
+
+import com.oracle.svm.hosted.meta.HostedMethod;
+
+/**
+ * This class holds info about a root methods callees that can be used during inlining. The root
+ * {@link HostedMethod}'s {@link com.oracle.svm.hosted.code.CompilationInfo} owns a collection of
+ * {@link CalleeInfo} objects.
+ */
+public class CalleeInfo {
+    /*
+     * This is the size of the graph starting at the root method before inlining this callee. Needed
+     * to calculate the callee's cost. It depends on the root graph, not the callee at all.
+     */
+    public int sizeBeforeInlining;
+    /*
+     * The last round that this Callee info was updated (callee was trialed). This is needed for
+     * handling multiple callsites within the same root scope.
+     */
+    public int lastRoundUpdated;
+    public HostedMethod method;
+
+    public CalleeInfo(HostedMethod method, int lastRoundUpdated) {
+        this.method = method;
+        this.lastRoundUpdated = lastRoundUpdated;
+    }
+}

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompilationInfo.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompilationInfo.java
@@ -24,6 +24,8 @@
  */
 package com.oracle.svm.hosted.code;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -45,6 +47,13 @@ import com.oracle.svm.hosted.code.CompileQueue.ParseHooks;
 import com.oracle.svm.hosted.meta.HostedMethod;
 
 public class CompilationInfo {
+    public int sizeLastRound;
+    public AtomicLong callsites = new AtomicLong();
+    // Flag to indicate that one of this method's callees has been inlined into it.
+    public volatile boolean hasChanged;
+    // Callees that have been evaluated but did not meet the inlining threshold.
+    public Map<HostedMethod, CalleeInfo> callees = new HashMap<>(8);
+
 
     protected final HostedMethod method;
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/InliningGraphDecoder.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/InliningGraphDecoder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2025, IBM Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.hosted.code;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.oracle.graal.pointsto.flow.AnalysisParsedGraph;
+import com.oracle.svm.hosted.meta.HostedMethod;
+
+import jdk.graal.compiler.bytecode.BytecodeProvider;
+import jdk.graal.compiler.nodes.EncodedGraph;
+import jdk.graal.compiler.nodes.StructuredGraph;
+import jdk.graal.compiler.nodes.graphbuilderconf.InlineInvokePlugin;
+import jdk.graal.compiler.nodes.java.MethodCallTargetNode;
+import jdk.graal.compiler.phases.util.Providers;
+import jdk.graal.compiler.replacements.PEGraphDecoder;
+
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+
+/** This is a general inlining decoder that is used for both trivial inlining and single callsite inlining.
+ * Different plugins allow for different functionality.*/
+class InliningGraphDecoder extends PEGraphDecoder {
+
+    InliningGraphDecoder(StructuredGraph graph, Providers providers, InlineInvokePlugin inliningPlugin) {
+        super(AnalysisParsedGraph.HOST_ARCHITECTURE, graph, providers, null,
+                null,
+                new InlineInvokePlugin[]{inliningPlugin},
+                null, null, null, null,
+                new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), true, false);
+    }
+
+    @Override
+    protected EncodedGraph lookupEncodedGraph(ResolvedJavaMethod method, BytecodeProvider intrinsicBytecodeProvider) {
+        return ((HostedMethod) method).compilationInfo.getCompilationGraph().getEncodedGraph();
+    }
+
+    @Override
+    protected LoopScope trySimplifyInvoke(PEMethodScope methodScope, LoopScope loopScope, InvokeData invokeData, MethodCallTargetNode callTarget) {
+        return super.trySimplifyInvoke(methodScope, loopScope, invokeData, callTarget);
+    }
+}

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/NonTrivialInliningGraphDecoder.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/NonTrivialInliningGraphDecoder.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2025, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2025, IBM Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.hosted.code;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.oracle.graal.pointsto.flow.AnalysisParsedGraph;
+import com.oracle.svm.core.util.VMError;
+import com.oracle.svm.hosted.meta.HostedMethod;
+import jdk.graal.compiler.bytecode.BytecodeProvider;
+import jdk.graal.compiler.nodes.EncodedGraph;
+import jdk.graal.compiler.nodes.StructuredGraph;
+import jdk.graal.compiler.nodes.ValueNode;
+import jdk.graal.compiler.nodes.graphbuilderconf.InlineInvokePlugin;
+import jdk.graal.compiler.nodes.java.MethodCallTargetNode;
+import jdk.graal.compiler.phases.contract.NodeCostUtil;
+import jdk.graal.compiler.phases.util.Providers;
+import jdk.graal.compiler.replacements.PEGraphDecoder;
+import jdk.graal.compiler.util.EconomicHashMap;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+
+/**
+ * This decoder is used after trivial inlining. It accounts for expected optimization benefit when
+ * making inlining decisions. Callees are "trialed" by first being inlined before a decision is
+ * made. This allows expected cost and benefit to be computed. If inlining is denied, then the nodes
+ * moved into the caller are rolled back similarly to what done in the
+ * {@link com.oracle.graal.pointsto.phases.InlineBeforeAnalysisGraphDecoder}.
+ */
+class NonTrivialInliningGraphDecoder extends PEGraphDecoder {
+    public class NonTrivialInliningMethodScope extends PEMethodScope {
+        public EconomicHashMap<ResolvedJavaMethod, Integer> newCallees;
+
+        NonTrivialInliningMethodScope(StructuredGraph targetGraph, PEMethodScope caller, LoopScope callerLoopScope, EncodedGraph encodedGraph, ResolvedJavaMethod method,
+                        InvokeData invokeData, int inliningDepth, ValueNode[] arguments) {
+            super(targetGraph, caller, callerLoopScope, encodedGraph, method, invokeData, inliningDepth, arguments);
+            newCallees = new EconomicHashMap<>(4);
+        }
+
+    }
+
+    boolean inlinedDuringDecoding;
+    int round;
+
+    NonTrivialInliningGraphDecoder(StructuredGraph graph, Providers providers, com.oracle.svm.hosted.code.CompileQueue.NonTrivialInliningPlugin inliningPlugin, int round) {
+        super(AnalysisParsedGraph.HOST_ARCHITECTURE, graph, providers, null,
+                        null,
+                        new InlineInvokePlugin[]{inliningPlugin},
+                        null, null, null, null,
+                        new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), true, false);
+        this.round = round;
+    }
+
+    @Override
+    protected EncodedGraph lookupEncodedGraph(ResolvedJavaMethod method, BytecodeProvider intrinsicBytecodeProvider) {
+        return ((HostedMethod) method).compilationInfo.getCompilationGraph().getEncodedGraph();
+    }
+
+    @Override
+    protected LoopScope trySimplifyInvoke(PEMethodScope methodScope, LoopScope loopScope, InvokeData invokeData, MethodCallTargetNode callTarget) {
+        return super.trySimplifyInvoke(methodScope, loopScope, invokeData, callTarget);
+    }
+
+    @Override
+    protected PEMethodScope createMethodScope(StructuredGraph targetGraph, PEMethodScope caller, LoopScope callerLoopScope, EncodedGraph encodedGraph, ResolvedJavaMethod method, InvokeData invokeData,
+                    int inliningDepth, ValueNode[] arguments) {
+        return new NonTrivialInliningMethodScope(targetGraph, caller, callerLoopScope, encodedGraph, method, invokeData, inliningDepth, arguments);
+    }
+
+    /**
+     * Calculate the size before inlining. It will be used later to calculate the callee cost when
+     * making inlining decisions.
+     */
+    @Override
+    protected LoopScope doInline(PEMethodScope methodScope, LoopScope loopScope, InvokeData invokeData, InlineInvokePlugin.InlineInfo inlineInfo, ValueNode[] arguments) {
+        // First, get the root method
+        PEMethodScope scope = methodScope;
+        while (scope.caller != null) {
+            scope = scope.caller;
+        }
+        HostedMethod root = (HostedMethod) scope.method;
+        HostedMethod callee = (HostedMethod) inlineInfo.getMethodToInline();
+        // If needed, create a CalleeInfo for the current callee
+        if (!root.compilationInfo.callees.containsKey(callee)) {
+            // If this callee is inlined, this CalleeInfo will not survive beyond the current round.
+            root.compilationInfo.callees.put(callee, new CalleeInfo(callee, round));
+        }
+        /*
+         * Stash the graph size in the CalleeInfo. Recursion (due to multiple callsites at different
+         * depths) should not be a problem since we only go one level deep per round.
+         */
+        root.compilationInfo.callees.get(callee).sizeBeforeInlining = NodeCostUtil.computeGraphSize(graph);
+        return super.doInline(methodScope, loopScope, invokeData, inlineInfo, arguments);
+    }
+
+    boolean canInline(PEMethodScope inlineScope, HostedMethod root, HostedMethod callee) {
+        if (callee.shouldBeInlined()) {
+            return true;
+        }
+
+        CalleeInfo calleeInfo = root.compilationInfo.callees.get(callee);
+        VMError.guarantee(calleeInfo != null, "CalleeInfo should have been created in doInline");
+
+        double currentSize = NodeCostUtil.computeGraphSize(graph);
+        double calleeCost = (currentSize - calleeInfo.sizeBeforeInlining);
+        // Similar to the TrivialInliningPhase, we can be a bit more lenient with leaf methods
+        if (inlineScope.invokeCount == 0) {
+            calleeCost = calleeCost / 4.0;
+        }
+
+        double offset = 1.0;
+        double bc = (offset + inlineScope.benefit) * Math.pow(root.compilationInfo.callsites.get(), 2) / calleeCost;
+        /*
+         * Only inline the top method marked from previous round. On round 1 we don't inline
+         * anything.
+         */
+        double t1 = 5;
+        double t2 = 1;
+        double threshold = t1 * Math.pow(2, (calleeCost / (16 * t2)));
+        if (bc >= threshold) {
+            return true;
+        }
+        /*
+         * If we fail to inline, the CalleeInfo remains in the root's set, so we don't retrial it in
+         * future rounds unless it changes.
+         */
+        return false;
+    }
+
+    @Override
+    protected void finishInlining(MethodScope is) {
+        NonTrivialInliningMethodScope inlineScope = (NonTrivialInliningMethodScope) is;
+        PEMethodScope callerScope = inlineScope.caller;
+        HostedMethod callee = (HostedMethod) inlineScope.method;
+        LoopScope callerLoopScope = inlineScope.callerLoopScope;
+        InvokeData invokeData = inlineScope.invokeData;
+        HostedMethod root = (HostedMethod) callerScope.method;
+
+        VMError.guarantee(callerScope.caller == null, "Inliner should not be evaluating beyond the root's immediate callees");
+
+        if (!canInline(inlineScope, root, callee)) {
+            // This block is essentially the same as InlineBeforeAnalysisGraphDecoder#finishInlining
+            if (invokeData.invokePredecessor.next() != null) {
+                killControlFlowNodes(inlineScope, invokeData.invokePredecessor.next());
+                assert invokeData.invokePredecessor.next() == null : "Successor must have been a fixed node created in the aborted scope, which is deleted now";
+            }
+            invokeData.invokePredecessor.setNext(invokeData.invoke.asFixedNode());
+            if (inlineScope.exceptionPlaceholderNode != null) {
+                assert invokeData.invoke instanceof jdk.graal.compiler.nodes.InvokeWithExceptionNode : invokeData.invoke;
+                assert lookupNode(callerLoopScope, invokeData.exceptionOrderId) == inlineScope.exceptionPlaceholderNode : inlineScope;
+                registerNode(callerLoopScope, invokeData.exceptionOrderId, null, true, true);
+                ValueNode exceptionReplacement = makeStubNode(callerScope, callerLoopScope, invokeData.exceptionOrderId);
+                inlineScope.exceptionPlaceholderNode.replaceAtUsagesAndDelete(exceptionReplacement);
+            }
+            handleNonInlinedInvoke(callerScope, callerLoopScope, invokeData);
+            return;
+        }
+
+        /*
+         * Commit the callsite count updates for 2nd level callees being copied into the root scope.
+         */
+        for (var entry : inlineScope.newCallees.entrySet()) {
+            HostedMethod hMethod = (HostedMethod) entry.getKey();
+            hMethod.compilationInfo.callsites.addAndGet(entry.getValue());
+        }
+        // Inlining into this callsite removes it.
+        callee.compilationInfo.callsites.decrementAndGet();
+        // Remove callee from the "seen" set
+        root.compilationInfo.callees.remove(callee);
+
+        inlinedDuringDecoding = true;
+        super.finishInlining(inlineScope);
+    }
+}


### PR DESCRIPTION
# Summary
This PR improves Native Image inlining. The new inlining involves 3 steps:
1. Trivial inlining
2. Non-Trivial inlining
3. Single callsite inlining

### Trivial Inlining
This stage remains mostly the same with the original default inliner. It is a quick operation that inlines methods under a certain size threshold. I have updated the size computation to use `Node.estimatedNodeSize()` rather than a simple raw node count. 

### Non-Trivial Inlining
This step focuses on inlining methods that are predicted to yield good optimization benefit due to specialization from inlining. This is determined through "trialing" the inlining before committing it. 

### Single Callsite Inlining
This step focuses on methods that have only 1 callsite. The number of callsites for each method is counted during non-trivial inlining. This step is very similar to the trivial inlining step, but the criteria for inlining is not based on size.  