### PR TITLE
Use estimated node size in Trivial Inliner instead of raw node count

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -912,6 +912,9 @@ public class SubstrateOptions {
     @Option(help = "The maximum number of nodes in a graph allowed after trivial inlining.")//
     public static final HostedOptionKey<Integer> MaxNodesAfterTrivialInlining = new HostedOptionKey<>(Integer.MAX_VALUE);
 
+    @Option(help = "The maximum size of a graph allowed after trivial inlining.")//
+    public static final HostedOptionKey<Integer> MaxSizeAfterTrivialInlining = new HostedOptionKey<>(Integer.MAX_VALUE);
+
     @LayerVerifiedOption(kind = Kind.Changed, severity = Severity.Error)//
     @Option(help = "Saves stack base pointer on the stack on method entry.")//
     public static final HostedOptionKey<Boolean> PreserveFramePointer = new HostedOptionKey<>(false);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -893,14 +893,20 @@ public class SubstrateOptions {
     @Option(help = "file:doc-files/NeverInlineHelp.txt")//
     public static final HostedOptionKey<AccumulatingLocatableMultiOptionValue.Strings> NeverInlineTrivial = new HostedOptionKey<>(AccumulatingLocatableMultiOptionValue.Strings.build());
 
-    @Option(help = "Maximum number of nodes in a method so that it is considered trivial.")//
+    @Option(help = "Maximum number of nodes in a method so that it is considered trivial.", deprecated = true, deprecationMessage = "Use -XX:MaxTrivialMethodSize instead")//
     public static final HostedOptionKey<Integer> MaxNodesInTrivialMethod = new HostedOptionKey<>(20);
+
+    @Option(help = "Maximum number of nodes in a method so that it is considered trivial, if it does not have any invokes.", deprecated = true, deprecationMessage = "Use -XX:MaxTrivialLeafMethodSize instead")//
+    public static final HostedOptionKey<Integer> MaxNodesInTrivialLeafMethod = new HostedOptionKey<>(40);
+
+    @Option(help = "Maximum size of a method so that it is considered trivial.")//
+    public static final HostedOptionKey<Integer> MaxTrivialMethodSize = new HostedOptionKey<>(53);
+
+    @Option(help = "Maximum size of a method so that it is considered trivial, if it does not have any invokes.")//
+    public static final HostedOptionKey<Integer> MaxTrivialLeafMethodSize = new HostedOptionKey<>(106);
 
     @Option(help = "Maximum number of invokes in a method so that it is considered trivial (for testing only).")//
     public static final HostedOptionKey<Integer> MaxInvokesInTrivialMethod = new HostedOptionKey<>(1);
-
-    @Option(help = "Maximum number of nodes in a method so that it is considered trivial, if it does not have any invokes.")//
-    public static final HostedOptionKey<Integer> MaxNodesInTrivialLeafMethod = new HostedOptionKey<>(40);
 
     @Option(help = "The maximum number of nodes in a graph allowed after trivial inlining.")//
     public static final HostedOptionKey<Integer> MaxNodesAfterTrivialInlining = new HostedOptionKey<>(Integer.MAX_VALUE);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, 2026, IBM Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This PR makes the Trivial inliner switch from using raw node counting to `estimatedNodeSize()`. Using the estimated nodes size should give a more accurate prediction of code area than using the raw node count.


I have added new hosted options `MaxTrivialLeafMethodSize`  and `MaxTrivialMethodSize` while deprecating the old `MaxNodesInTrivialLeafMethod` and `MaxNodesInTrivialMethod`. The old node counting implementation can still be used, if either of the old hosted options are supplied at build time. 

**Overall, swapping node counting for estimated size does not seem to make much of a significant change in performance**: 

-----

Using [Renaissance](https://renaissance.dev/):

Test details:
 - Tested on Linux amd64
 - For stability during the build and during benchmark execution
   - Intel turbo boost disabled
   - CPU frequency pinned to 2100000kHz with cpupower
   - `cpupower frequency-set --governor performance`
   - Caches dropped before building with `sh -c 'echo 3 >/proc/sys/vm/drop_caches'`
   - Each benchmark was run multiple times. The first few runs are discounted as warm-up. 
  
Definitions:
 - _custom_ : The inliner with single callsite inlining implemented
 - _control_ : The old inliner with default settings. 
 - _Peak Build RSS_ : Peak RSS reported by the image builder.
 - _build time_ : total time taken by the image builder
 - _inline time_ : time taken only by the inlining operations
 - _duration_: Execution time of the Renaissance benchmark
 - _% improvement_ : Calculated as 100 * (old duration - new duration)/ old duration
 
Benchmark | Duration (ms) [old] | Duration (ms) [new] | % improvement | STDEV (ms) [old] | STDEV (ms) [new] | Code Area (MB) [old] | Code Area (MB) [new] | File Size (MB) [old] | File Size (MB) [new] | Inline Time (s) [old] | Inline Time (s) [new] | Build Time (s) [old] | Build Time (s) [new] | Peak Build RSS (GB) [old] | Peak Build RSS (GB) [new] | Total runs | Warm up runs
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
fj-kmeans | 6,360.19 | 6,319.61 | 0.638 | 157.63 | 121.59 | 7.39 | 7.48 | 19.38 | 19.5 | 0.8 | 0.8 | 38.2 | 39. | 1.74 | 1.76 | 30. | 20.
mnemonics | 10,263. | 10,261. | 0.019 | 61.5 | 92.2 | 7.42 | 7.51 | 19.5 | 19.57 | 0.8 | 0.8 | 39.4 | 38.8 | 1.77 | 1.75 | 16. | 6.
philosophers | 6,736. | 6,924.93 | -2.805 | 220.73 | 262.2 | 9.97 | 10.04 | 27.69 | 27.75 | 1. | 1. | 46.1 | 46.1 | 2.04 | 2.07 | 30. | 10.
par-mnemonics | 9,176.78 | 8,418.415 | 8.264 | 79.66 | 68.96 | 7.43 | 7.52 | 19.5 | 19.57 | 0.8 | 0.8 | 38.7 | 39.2 | 1.77 | 1.75 | 16. | 6.
reactors | 35,429.4 | 34,991. | 1.237 | 1,345. | 2,210. | 7.86 | 7.9 | 21.07 | 21.31 | 1.6 | 0.9 | 39.6 | 40.5 | 1.79 | 1.81 | 10. | 3.
scala-doku | 5,954.21 | 5,913.59 | 0.682 | 39.6 | 32.93 | 7.49 | 7.56 | 19.57 | 19.63 | 0.8 | 0.9 | 39.5 | 38.6 | 1.76 | 1.76 | 20. | 10.
future-genetic | 2,759. | 2,779. | -0.725 | 16.9 | 27.9 | 7.54 | 7.62 | 19.63 | 19.69 | 0.8 | 0.8 | 38.5 | 39.4 | 1.75 | 1.78 | 25. | 5.
akka-uct | 30,450.6 | 30,334.1 | 0.383 | 863.03 | 1,449.21 | 9.52 | 9.58 | 24.32 | 24.32 | 1. | 1. | 44.8 | 44.3 | 2.02 | 2. | 16. | 6.
scala-kmeans | 714.43 | 740.86 | -3.699 | 3.55 | 3.18 | 7.37 | 7.46 | 19.38 | 19.44 | 0.8 | 0.8 | 38.6 | 38.9 | 1.74 | 1.77 | 25. | 5.


-----

Using a [Quarkus hello-world rest benchmark](https://github.com/franz1981/quarkus-reactive-beer). This benchmark has 2 endpoints: "greeting" and "beer". Both return plaintext, but "beer" does a little more work.



Test details:
 - Tested on Linux amd64
 - For stability during the build and during benchmark execution
   - Intel turbo boost disabled
   - CPU frequency pinned to 2100000kHz with cpupower
   - `cpupower frequency-set --governor performance`
   - Caches dropped before building and running with `sh -c 'echo 3 >/proc/sys/vm/drop_caches'`
   - Both the control and custom configurations were built and run 5 times in an alternating fashion. The results were averaged. 
  
Definitions:
 -  _Req/s_ : Quarkus app throughput in requests per second
 - _% improvement_ : Calculated as 100 * (new throughput - old throughput)/ old throughput


Benchmark | Throughput (req/s) [old] | Throughput (req/s)  [new] | % improvement | Code Area (MB) [old] | Code Area (MB) [new] | File Size (MB) [old] | File Size (MB) [new] | Inline Time (s) [old] | Inline Time (s) [new] | Build Time (s) [old] | Build Time (s) [new] | Peak Build RSS (GB) [old] | Peak Build RSS (GB) [new]
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Greeting endpoint | 48,765.21 | 47,818.43 | -1.942 | 20.14 | 20.2 | 46.82 | 46.82 | 1.3 | 1.4 | 80. | 81. | 2.707 | 2.693
Beer endpoint | 23,222. | 23,614.5 | 1.69 | Same as above | Same as above | Same as above | Same as above | Same as above | Same as above | Same as above | Same as above | Same as above | Same as above






