### PR TITLE
Add an inlining stage for single callsite methods

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, 2026, IBM Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -885,6 +886,10 @@ public class SubstrateOptions {
     @LayerVerifiedOption(kind = Kind.Changed, severity = Severity.Error)//
     @Option(help = "Perform trivial method inlining in the AOT compiled native image")//
     public static final HostedOptionKey<Boolean> AOTTrivialInline = new HostedOptionKey<>(true);
+
+    @LayerVerifiedOption(kind = Kind.Changed, severity = Severity.Error)//
+    @Option(help = "Perform single callsite method inlining in the AOT compiled native image")//
+    public static final HostedOptionKey<Boolean> AOTSingleCallsiteInline = new HostedOptionKey<>(true);
 
     @LayerVerifiedOption(kind = Kind.Removed, severity = Severity.Warn, positional = false)//
     @Option(help = "file:doc-files/NeverInlineHelp.txt", type = OptionType.Debug)//

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompilationInfo.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompilationInfo.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, 2026, IBM Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +26,7 @@
 package com.oracle.svm.hosted.code;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import jdk.graal.compiler.core.common.CompilationIdentifier;
@@ -45,6 +47,9 @@ import com.oracle.svm.hosted.code.CompileQueue.ParseHooks;
 import com.oracle.svm.hosted.meta.HostedMethod;
 
 public class CompilationInfo {
+    int sizeLastRound;
+
+    AtomicInteger callsites = new AtomicInteger();
 
     protected final HostedMethod method;
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompileQueue.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompileQueue.java
@@ -1060,7 +1060,7 @@ public class CompileQueue {
     }
 
     private boolean makeSingleCallsiteInlineDecision(HostedMethod caller, HostedMethod callee) {
-        if (!isCalleeGraphAvailable(caller, callee)) {
+        if (!isCalleeGraphAvailable(caller, callee) || !callee.getWrapped().canBeInlined()) {
             return false;
         }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompileQueue.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompileQueue.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2025, IBM Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +42,6 @@ import java.util.concurrent.ConcurrentMap;
 import org.graalvm.nativeimage.ImageSingletons;
 
 import com.oracle.graal.pointsto.api.PointstoOptions;
-import com.oracle.graal.pointsto.flow.AnalysisParsedGraph;
 import com.oracle.graal.pointsto.meta.HostedProviders;
 import com.oracle.graal.pointsto.util.CompletionExecutor;
 import com.oracle.graal.pointsto.util.CompletionExecutor.DebugContextRunnable;
@@ -88,7 +88,6 @@ import com.oracle.svm.util.OriginalClassProvider;
 
 import jdk.graal.compiler.api.replacements.Fold;
 import jdk.graal.compiler.asm.Assembler;
-import jdk.graal.compiler.bytecode.BytecodeProvider;
 import jdk.graal.compiler.code.CompilationResult;
 import jdk.graal.compiler.core.GraalCompiler;
 import jdk.graal.compiler.core.common.CompilationIdentifier;
@@ -112,7 +111,6 @@ import jdk.graal.compiler.lir.framemap.FrameMap;
 import jdk.graal.compiler.lir.phases.LIRSuites;
 import jdk.graal.compiler.nodes.CallTargetNode;
 import jdk.graal.compiler.nodes.ConstantNode;
-import jdk.graal.compiler.nodes.EncodedGraph;
 import jdk.graal.compiler.nodes.FrameState;
 import jdk.graal.compiler.nodes.GraphEncoder;
 import jdk.graal.compiler.nodes.GraphState.StageFlag;
@@ -127,6 +125,7 @@ import jdk.graal.compiler.nodes.graphbuilderconf.InlineInvokePlugin;
 import jdk.graal.compiler.nodes.java.MethodCallTargetNode;
 import jdk.graal.compiler.nodes.spi.CoreProviders;
 import jdk.graal.compiler.options.OptionValues;
+import jdk.graal.compiler.phases.contract.NodeCostUtil;
 import jdk.graal.compiler.phases.OptimisticOptimizations;
 import jdk.graal.compiler.phases.Phase;
 import jdk.graal.compiler.phases.PhaseSuite;
@@ -170,6 +169,12 @@ public class CompileQueue {
         }
     }
 
+    /*
+     * Use the same fallback as
+     * "An Optimization-Driven Incremental Inline Substitution Algorithm for Just-in-Time Compilers"
+     */
+    private static final int FALLBACK_SIZE = 50000;
+
     protected final HostedUniverse universe;
     private final Boolean deoptimizeAll;
     protected final List<Policy> policies;
@@ -202,12 +207,20 @@ public class CompileQueue {
 
     private final ResolvedJavaType generatedFoldInvocationPluginType;
 
-    public record UnpublishedTrivialMethods(CompilationGraph unpublishedGraph, boolean newlyTrivial) {
+    public record UnpublishedMethodInfo(CompilationGraph unpublishedGraph, boolean newlyTrivial) {
     }
 
-    private final ConcurrentMap<HostedMethod, UnpublishedTrivialMethods> unpublishedTrivialMethods = new ConcurrentHashMap<>();
+    private final ConcurrentMap<HostedMethod, UnpublishedMethodInfo> unpublishedMethods = new ConcurrentHashMap<>();
+
+    /*
+     * Edge case handling: For each method, track that last round that Single Callsite Inlining was
+     * unsuccessful
+     */
+    private final ConcurrentMap<HostedMethod, Integer> sciLastRoundFailed = new ConcurrentHashMap<>();
 
     private final LayeredDispatchTableFeature layeredDispatchTableSupport = ImageLayerBuildingSupport.buildingSharedLayer() ? LayeredDispatchTableFeature.singleton() : null;
+
+    private int inliningRound = 0;
 
     public abstract static class CompileReason {
         /**
@@ -366,6 +379,27 @@ public class CompileQueue {
         }
     }
 
+    protected class SingleCallsiteInlineTask implements Task {
+
+        private final HostedMethod method;
+        private final Description description;
+
+        SingleCallsiteInlineTask(HostedMethod method) {
+            this.method = method;
+            this.description = new Description(method, method.getName());
+        }
+
+        @Override
+        public void run(DebugContext debug) {
+            doInlineSingleCallsite(debug, method);
+        }
+
+        @Override
+        public Description getDescription() {
+            return description;
+        }
+    }
+
     public class ParseTask implements Task {
 
         protected final CompileReason reason;
@@ -454,7 +488,11 @@ public class CompileQueue {
                 ImageSingletons.lookup(HostedHeapDumpFeature.class).beforeInlining();
             }
             try (ProgressReporter.ReporterClosable _ = reporter.printInlining()) {
+                // The trivial stage must be run to handle any forced inlining due to annotations
                 inlineTrivialMethods(debug);
+                if (SubstrateOptions.AOTSingleCallsiteInline.getValue()) {
+                    inlineSingleCallsiteMethods(debug);
+                }
             }
             if (ImageSingletons.contains(HostedHeapDumpFeature.class)) {
                 ImageSingletons.lookup(HostedHeapDumpFeature.class).afterInlining();
@@ -753,12 +791,10 @@ public class CompileQueue {
     }
 
     protected void inlineTrivialMethods(DebugContext debug) throws InterruptedException {
-        int round = 0;
+        inliningRound = 0;
         do {
-            ProgressReporter.singleton().reportStageProgress();
-            inliningProgress = false;
-            round++;
-            try (Indent _ = debug.logAndIndent("==== Trivial Inlining  round %d%n", round)) {
+            beginRound();
+            try (Indent _ = debug.logAndIndent("==== Trivial Inlining  round %d%n", inliningRound)) {
                 runOnExecutor(() -> {
                     universe.getMethods().forEach(method -> {
                         assert method.isOriginalMethod();
@@ -771,15 +807,102 @@ public class CompileQueue {
                     });
                 });
             }
-            for (Map.Entry<HostedMethod, UnpublishedTrivialMethods> entry : unpublishedTrivialMethods.entrySet()) {
+            for (Map.Entry<HostedMethod, UnpublishedMethodInfo> entry : unpublishedMethods.entrySet()) {
                 entry.getKey().compilationInfo.setCompilationGraph(entry.getValue().unpublishedGraph);
                 if (entry.getValue().newlyTrivial) {
                     inliningProgress = true;
                     entry.getKey().compilationInfo.setTrivialMethod();
                 }
             }
-            unpublishedTrivialMethods.clear();
+            unpublishedMethods.clear();
         } while (inliningProgress);
+    }
+
+    /**
+     * Single callsite methods should be able to be inlined without duplicating code area. Single
+     * callsite inlining happens after trivial inlining to maximize the amount of trivial inlining
+     * possible.
+     *
+     * Say M1 is trivial and M2 has a single callsite, with M1 as the caller. If we inline M2 first,
+     * then M1 will likely no longer be trivial. If we inline M1 first, then M2 will no longer have
+     * a single callsite. It's preferable to miss out on a single instance of inlining rather than
+     * many - so trivial methods are inlined first.
+     */
+    @SuppressWarnings("try")
+    protected void inlineSingleCallsiteMethods(DebugContext debug) throws InterruptedException {
+        inliningRound = 0;
+        // First count callsites
+        try (Indent _ = debug.logAndIndent("==== Single Callsite Inlining: counting callsites")) {
+            runOnExecutor(() -> {
+                universe.getMethods().forEach(method -> {
+                    assert method.isOriginalMethod();
+                    for (MultiMethod multiMethod : method.getAllMultiMethods()) {
+                        HostedMethod hMethod = (HostedMethod) multiMethod;
+                        if (hMethod.compilationInfo.getCompilationGraph() != null) {
+                            executor.execute(new SingleCallsiteInlineTask(hMethod));
+                        }
+                    }
+                });
+            });
+        }
+
+        // Inline single callsite methods
+        do {
+            beginRound();
+            try (Indent _ = debug.logAndIndent("==== Single Callsite Inlining  round %n")) {
+                runOnExecutor(() -> {
+                    universe.getMethods().forEach(method -> {
+                        assert method.isOriginalMethod();
+                        for (MultiMethod multiMethod : method.getAllMultiMethods()) {
+                            HostedMethod hMethod = (HostedMethod) multiMethod;
+                            if (shouldEvaluateRootForSingleCallsiteInlining(hMethod)) {
+                                executor.execute(new SingleCallsiteInlineTask(hMethod));
+                            }
+                        }
+                    });
+                });
+            }
+            // Publish modified graphs
+            for (Map.Entry<HostedMethod, UnpublishedMethodInfo> entry : unpublishedMethods.entrySet()) {
+                entry.getKey().compilationInfo.setCompilationGraph(entry.getValue().unpublishedGraph);
+                inliningProgress = true;
+            }
+            unpublishedMethods.clear();
+        } while (inliningProgress);
+    }
+
+    private boolean shouldEvaluateRootForSingleCallsiteInlining(HostedMethod root) {
+        if (root.compilationInfo.getCompilationGraph() == null) {
+            return false;
+        }
+
+        if (inliningRound == 1) {
+            /*
+             * Skip roots that are themselves single callsite methods. Otherwise, it's possible that
+             * the root and some of its callees are both single callsite methods. In such cases, the
+             * root becomes unreachable and we wasted effort inlining its callees.
+             */
+            if (root.compilationInfo.callsites.get() != 1) {
+                return true;
+            }
+        } else {
+            /*
+             * After the first round, we must visit roots that are single callsite methods which
+             * failed the inlining threshold last round. Otherwise, their callees will never get
+             * evaluated.
+             */
+            Integer lastRoundFailed = sciLastRoundFailed.get(root);
+            if (lastRoundFailed != null && lastRoundFailed.equals(inliningRound - 1)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void beginRound() {
+        ProgressReporter.singleton().reportStageProgress();
+        inliningProgress = false;
+        inliningRound++;
     }
 
     class TrivialInliningPlugin implements InlineInvokePlugin {
@@ -801,35 +924,35 @@ public class CompileQueue {
         }
     }
 
-    class InliningGraphDecoder extends PEGraphDecoder {
+    /** This plugin will allow inlining methods that have a single callsite. */
+    class SingleCallsiteInliningPlugin implements InlineInvokePlugin {
+        boolean inlinedDuringDecoding;
 
-        InliningGraphDecoder(StructuredGraph graph, Providers providers, TrivialInliningPlugin inliningPlugin) {
-            super(AnalysisParsedGraph.HOST_ARCHITECTURE, graph, providers, null,
-                            null,
-                            new InlineInvokePlugin[]{inliningPlugin},
-                            null, null, null, null,
-                            new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), true, false);
+        @Override
+        public InlineInfo shouldInlineInvoke(GraphBuilderContext b, ResolvedJavaMethod method, ValueNode[] args) {
+            if (makeSingleCallsiteInlineDecision((HostedMethod) b.getMethod(), (HostedMethod) method) && b.recursiveInliningDepth(method) == 0) {
+                return InlineInfo.createStandardInlineInfo(method);
+            } else {
+                return InlineInfo.DO_NOT_INLINE_WITH_EXCEPTION;
+            }
         }
 
         @Override
-        protected EncodedGraph lookupEncodedGraph(ResolvedJavaMethod method, BytecodeProvider intrinsicBytecodeProvider) {
-            return ((HostedMethod) method).compilationInfo.getCompilationGraph().getEncodedGraph();
-        }
-
-        @Override
-        protected LoopScope trySimplifyInvoke(PEMethodScope methodScope, LoopScope loopScope, InvokeData invokeData, MethodCallTargetNode callTarget) {
-            return super.trySimplifyInvoke(methodScope, loopScope, invokeData, callTarget);
+        public void notifyAfterInline(ResolvedJavaMethod methodToInline) {
+            inlinedDuringDecoding = true;
         }
     }
 
     // Wrapper to clearly identify phase
-    class TrivialInlinePhase extends Phase {
-        final InliningGraphDecoder decoder;
+    class InlinePhase extends Phase {
+        final PEGraphDecoder decoder;
         final HostedMethod method;
+        final String name;
 
-        TrivialInlinePhase(InliningGraphDecoder decoder, HostedMethod method) {
+        InlinePhase(PEGraphDecoder decoder, HostedMethod method, String name) {
             this.decoder = decoder;
             this.method = method;
+            this.name = name;
         }
 
         @Override
@@ -839,10 +962,11 @@ public class CompileQueue {
 
         @Override
         public CharSequence getName() {
-            return "TrivialInline";
+            return name;
         }
     }
 
+    @SuppressWarnings("try")
     private void doInlineTrivial(DebugContext debug, HostedMethod method) {
         /*
          * Before doing any work, check if there is any potential for inlining.
@@ -866,7 +990,7 @@ public class CompileQueue {
         try (var _ = debug.scope("InlineTrivial", graph, method, this)) {
             var inliningPlugin = new TrivialInliningPlugin();
             var decoder = new InliningGraphDecoder(graph, providers, inliningPlugin);
-            new TrivialInlinePhase(decoder, method).apply(graph);
+            new InlinePhase(decoder, method, "TrivialInline").apply(graph);
 
             if (inliningPlugin.inlinedDuringDecoding) {
                 CanonicalizerPhase.create().apply(graph, providers);
@@ -891,7 +1015,7 @@ public class CompileQueue {
                      * non-deterministic. This is why we are saving graphs to be published at the
                      * end of each round.
                      */
-                    unpublishedTrivialMethods.put(method, new UnpublishedTrivialMethods(CompilationGraph.encode(graph), checkNewlyTrivial(method, graph)));
+                    unpublishedMethods.put(method, new UnpublishedMethodInfo(CompilationGraph.encode(graph), checkNewlyTrivial(method, graph)));
                 }
             }
         } catch (Throwable ex) {
@@ -899,13 +1023,28 @@ public class CompileQueue {
         }
     }
 
+    private void doInlineSingleCallsite(DebugContext debug, HostedMethod method) {
+        var providers = runtimeConfig.lookupBackend(method).getProviders();
+        var graph = method.compilationInfo.createGraph(debug, getCustomizedOptions(method, debug), CompilationIdentifier.INVALID_COMPILATION_ID, false);
+        try (var _ = debug.scope("InlineSingleCallsites", graph, method, this)) {
+            var inliningPlugin = new SingleCallsiteInliningPlugin();
+            var decoder = new InliningGraphDecoder(graph, providers, inliningPlugin);
+            new InlinePhase(decoder, method, "SingleCallsiteInline").apply(graph);
+
+            if (inliningPlugin.inlinedDuringDecoding) {
+                CanonicalizerPhase.create().apply(graph, providers);
+                unpublishedMethods.put(method, new UnpublishedMethodInfo(CompilationGraph.encode(graph), true));
+            }
+            if (inliningPlugin.inlinedDuringDecoding || inliningRound == 0) {
+                method.compilationInfo.sizeLastRound = NodeCostUtil.computeGraphSize(graph);
+            }
+        } catch (Throwable ex) {
+            throw debug.handle(ex);
+        }
+    }
+
     private boolean makeInlineDecision(HostedMethod method, HostedMethod callee) {
-        if (!LayeredImageOptions.UseSharedLayerStrengthenedGraphs.getValue() && callee.compilationInfo.getCompilationGraph() == null) {
-            /*
-             * We have compiled this method in a prior layer or this method's compilation is delayed
-             * to the application layer, but don't have the graph available here.
-             */
-            assert callee.isCompiledInPriorLayer() || callee.wrapped.isDelayed() : method;
+        if (!isCalleeGraphAvailable(method, callee)) {
             return false;
         }
         if (universe.hostVM().neverInlineTrivial(method.getWrapped(), callee.getWrapped())) {
@@ -918,6 +1057,40 @@ public class CompileQueue {
             return true;
         }
         return false;
+    }
+
+    private boolean makeSingleCallsiteInlineDecision(HostedMethod caller, HostedMethod callee) {
+        if (!isCalleeGraphAvailable(caller, callee)) {
+            return false;
+        }
+
+        // During the preliminary single callsite inlining round we must count callsites
+        if (inliningRound == 0) {
+            callee.compilationInfo.callsites.incrementAndGet();
+            return false;
+        }
+
+        if (callee.compilationInfo.callsites.get() != 1) {
+            return false;
+        }
+
+        if (caller.compilationInfo.sizeLastRound + callee.compilationInfo.sizeLastRound >= FALLBACK_SIZE) {
+            sciLastRoundFailed.put(callee, inliningRound);
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean isCalleeGraphAvailable(HostedMethod caller, HostedMethod callee) {
+        if (!LayeredImageOptions.UseSharedLayerStrengthenedGraphs.getValue() && callee.compilationInfo.getCompilationGraph() == null) {
+            /*
+             * We have compiled this method in a prior layer or this method's compilation is delayed
+             * to the application layer, but don't have the graph available here.
+             */
+            assert callee.isCompiledInPriorLayer() || callee.wrapped.isDelayed() : caller;
+            return false;
+        }
+        return true;
     }
 
     private static boolean mustNotAllocateCallee(HostedMethod method) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/InliningGraphDecoder.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/InliningGraphDecoder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, 2026, IBM Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.hosted.code;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.oracle.graal.pointsto.flow.AnalysisParsedGraph;
+import com.oracle.svm.hosted.meta.HostedMethod;
+
+import jdk.graal.compiler.bytecode.BytecodeProvider;
+import jdk.graal.compiler.nodes.EncodedGraph;
+import jdk.graal.compiler.nodes.StructuredGraph;
+import jdk.graal.compiler.nodes.graphbuilderconf.InlineInvokePlugin;
+import jdk.graal.compiler.phases.util.Providers;
+import jdk.graal.compiler.replacements.PEGraphDecoder;
+
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+
+/**
+ * This is a general inlining decoder that is used for both trivial inlining and single callsite
+ * inlining. Different plugins allow for different functionality.
+ */
+class InliningGraphDecoder extends PEGraphDecoder {
+
+    InliningGraphDecoder(StructuredGraph graph, Providers providers, InlineInvokePlugin inliningPlugin) {
+        super(AnalysisParsedGraph.HOST_ARCHITECTURE, graph, providers, null,
+                        null,
+                        new InlineInvokePlugin[]{inliningPlugin},
+                        null, null, null, null,
+                        new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), true, false);
+    }
+
+    @Override
+    protected EncodedGraph lookupEncodedGraph(ResolvedJavaMethod method, BytecodeProvider intrinsicBytecodeProvider) {
+        return ((HostedMethod) method).compilationInfo.getCompilationGraph().getEncodedGraph();
+    }
+}


### PR DESCRIPTION
### Summary

This PR adds a new inlining stage for single callsite methods. We should be able to benefit from inlining single callsite methods without paying the code area price. This stage is done completely independently of the normal Trivial inlining stage. It can be turned off using the `AOTSingleCallsiteInline` hosted option, similar to the existing `AOTTrivialInline` option. 

This inlining stage works by first counting the callsites for each method in the universe, then inlining those methods specifically.  Similar to the Trivial inlining stage, rounds are used. However, usually only 1 or 2 rounds will ever execute. An additional round will execute only when an inlining candidate exceeds the fallback threshold (rare).

Overall, adding this inlining stage improves performance.  See a few benchmark results below.

-----
### Results


#### Using [**Renaissance**](https://renaissance.dev/):
Test details:
 - Tested on Linux amd64
 - For stability during the build and during benchmark execution
   - Intel turbo boost disabled
   - CPU frequency pinned to 2100000kHz with cpupower
   - `cpupower frequency-set --governor performance`
   - Caches dropped before building with `sh -c 'echo 3 >/proc/sys/vm/drop_caches'`
   - Each benchmark was run multiple times. The first few runs are discounted as warm-up. 
  
Definitions:
 - _new_ : The inliner with single callsite inlining implemented
 - _old_ : The old inliner with default settings. 
 - _duration_: Execution time of the Renaissance benchmark
 - _% improvement_ : Calculated as 100 * (old duration - new duration)/ old duration
 - _STDEV_ Standard deviation in benchmark run duration
 - _inline time_ : time taken only by the inlining operations
 - _build time_ : total time taken by the image builder
 - _Peak Build RSS_ : Peak RSS reported by the image builder.

Benchmark | Duration (ms) [old] | Duration (ms) [new] | % improvement | STDEV (ms) [old] | STDEV (ms) [new] | Code Area (MB) [old] | Code Area (MB) [new] | File Size (MB) [old] | File Size (MB) [new] | Inline Time (s) [old] | Inline Time (s) [new] | Build Time (s) [old] | Build Time (s) [new] | Peak Build RSS (GB) [old] | Peak Build RSS (GB) [new] | Total runs | Warm up runs
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
mnemonics | 11127.89 | 10368.52 | 6.824 | 77.685 | 70.535 | 7.42 | 7.49 | 19.5 | 19.5 | 0.8 | 1.25 | 38.85 | 39.35 | 1.735 | 1.82 | 16. | 6.
reactors | 35201.1 | 33134.3 | 5.871 | 564.39 | 1057. | 7.86 | 7.94 | 21.07 | 21.13 | 0.8 | 1.3 | 40.1 | 41.2 | 1.81 | 1.93 | 10. | 3.
future-genetic | 2743.19 | 2684.55 | 2.138 | 16.91 | 19.525 | 7.54 | 7.6 | 19.63 | 19.69 | 0.75 | 1.3 | 39.05 | 39.65 | 1.74 | 1.815 | 25. | 5.
par-mnemonics | 9192.965 | 8634.455 | 6.075 | 89.955 | 60.565 | 7.43 | 7.49 | 19.5 | 19.5 | 0.8 | 1.2 | 38.7 | 39.35 | 1.74 | 1.8 | 16. | 6.
philosophers | 6818.26 | 6422.29 | 5.807 | 245.965 | 209.43 | 9.97 | 10.21 | 27.69 | 27.88 | 1. | 1.4 | 46.6 | 47.6 | 2.05 | 2.2 | 30. | 10.
scala-doku | 5911.5 | 5931.97 | -0.346 | 51.76 | 21.15 | 7.49 | 7.55 | 19.57 | 19.57 | 0.8 | 1.1 | 39.1 | 40. | 1.76 | 1.84 | 20. | 10.
fj-kmeans | 6422.1 | 6488.66 | -1.036 | 122.97 | 94.03 | 7.39 | 7.46 | 19.38 | 19.44 | 0.7 | 1.2 | 38.3 | 40. | 1.72 | 1.8 | 30. | 20.
akka-uct | 30300.175 | 30102.31 | 0.653 | 836.825 | 1013.41 | 9.52 | 9.59 | 24.32 | 24.32 | 1. | 1.5 | 45.2 | 45.7 | 2.03 | 2.07 | 10. | 5.
scala-kmeans | 722.883 | 616.075 | 14.775 | 3.39 | 4.1 | 7.37 | 7.46 | 19.38 | 19.44 | 0.8 | 1.3 | 38.5 | 39. | 1.74 | 1.79 | 25. | 5.


#### Using a [Quarkus hello-world rest benchmark](https://github.com/franz1981/quarkus-reactive-beer):
This benchmark has 2 endpoints: "greeting" and "beer". Both return plaintext, but "beer" does a little more work. 

Test details:
 - Tested on Linux amd64
 - For stability during the build and during benchmark execution
   - Intel turbo boost disabled
   - CPU frequency pinned to 2100000kHz with cpupower
   - `cpupower frequency-set --governor performance`
   - Caches dropped before building and running with `sh -c 'echo 3 >/proc/sys/vm/drop_caches'`
   - Both the old and new configurations were built and run 5 times in an alternating fashion. The results were averaged. 
   - Pinned the load driver (Hyperfoil) to 4 CPUs and the Quarkus app to 2 other CPUs
  
New Definitions:
 -  _Req/s_ : Quarkus app throughput in requests per second
 - _% improvement_ : Calculated as 100 * (new throughput - old throughput)/ old throughput

Benchmark | Throughput (req/s) [old] | Throughput (req/s)  [new] | % improvement | Code Area (MB) [old] | Code Area (MB) [new] | File Size (MB) [old] | File Size (MB) [new] | Inline Time (s) [old] | Inline Time (s) [new] | Build Time (s) [old] | Build Time (s) [new] | Peak Build RSS (GB) [old] | Peak Build RSS (GB) [new]
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
"greeting" endpoint | 48161.4 | 53484.8 | 11.053 | 20.14 | 20.52 | 46.82 | 47.19 | 1.388 | 2.371 | 81.5 | 82.429 | 2.704 | 2.83
"beer" endpoint | 23598.25 | 26249.5 | 11.235 | Same as above | Same as above | Same as above | Same as above | Same as above | Same as above | Same as above | Same as above | Same as above | Same as above

--------------------
### Other notes

**Improving the Trivial Inlining stage**
I also tried improving the Trivial inlining stage by switching from using raw node counting to `estimatedNodeSize()`. That should give a more accurate prediction of code area than using the raw node count. However, this only resulted in improvement in one Renaissance benchmark (par-mnemonics), so I am not sure whether this change is worth it.  You can see the code for that here https://github.com/roberttoyonaga/graal/pull/4.

**Unit tests**
I was not able to find any existing tests for the Native Image Inliner. I have manually checked for correctness by building with debug info and checking the generated assembly. However, I don't think that approach translates well to unit tests. Another option I was considering is testing for correctness at the Graal IR level. However, I'm not sure the best way to go about doing this so I decided it was best to ask for advice here before  investing too much in a particular approach. 


