### PR TITLE
[GR-67169] Follow-up fixes for JFR emergency dump PR

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/jfr/PosixJfrEmergencyDumpSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/jfr/PosixJfrEmergencyDumpSupport.java
@@ -200,10 +200,10 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
             try {
                 iterateRepository(sortedChunkFilenames);
                 writeEmergencyDumpFile(sortedChunkFilenames);
-                closeEmergencyDumpFile();
             } finally {
                 freeChunkFilenames(sortedChunkFilenames);
                 GrowableWordArrayAccess.freeData(sortedChunkFilenames);
+                closeEmergencyDumpFile();
                 sortedChunkFilenames = Word.nullPointer();
             }
         }
@@ -325,7 +325,11 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
 
         for (int i = 0; i < sortedChunkFilenames.getSize(); i++) {
             CCharPointer fn = (CCharPointer) ((Pointer) GrowableWordArrayAccess.get(sortedChunkFilenames, i));
-            RawFileDescriptor chunkFd = getFileSupport().open(fullyQualified(fn), FileAccessMode.READ);
+            CCharPointer chunkPath = fullyQualified(fn);
+            if (chunkPath.isNull()) {
+                continue;
+            }
+            RawFileDescriptor chunkFd = getFileSupport().open(chunkPath, FileAccessMode.READ);
             if (getFileSupport().isValid(chunkFd)) {
 
                 // Read it's size
@@ -434,7 +438,7 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
         }
 
         // Verify it can be opened and receive a valid file descriptor
-        RawFileDescriptor chunkFd = getFileSupport().open(chunkPath, FileAccessMode.READ_WRITE);
+        RawFileDescriptor chunkFd = getFileSupport().open(chunkPath, FileAccessMode.READ);
         if (!getFileSupport().isValid(chunkFd)) {
             return false;
         }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/jfr/PosixJfrEmergencyDumpSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/jfr/PosixJfrEmergencyDumpSupport.java
@@ -191,6 +191,7 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
                 writeEmergencyDumpFile(sortedChunkFilenames);
                 closeEmergencyDumpFile();
             } finally {
+                freeChunkFilenames(sortedChunkFilenames);
                 GrowableWordArrayAccess.freeData(sortedChunkFilenames);
                 sortedChunkFilenames = Word.nullPointer();
             }
@@ -249,11 +250,18 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
                 // Filter files
                 CCharPointer fn = entry.d_name();
                 if (filter(fn)) {
-                    // Append filtered files to list
-                    if (!GrowableWordArrayAccess.add(gwa, (Word) (Pointer) fn, NmtCategory.JFR)) {
-                        SubstrateJVM.getLogging().logJfrSystemError("Unable to add chunk filename to list during jfr emergency dump");
+                    CCharPointer fnCopy = LibC.strdup(fn);
+                    if (fnCopy.isNull()) {
+                        SubstrateJVM.getLogging().logJfrSystemError("Unable to copy chunk filename during jfr emergency dump");
+                        continue;
                     }
-                    count++;
+                    // Append filtered files to list
+                    if (!GrowableWordArrayAccess.add(gwa, (Word) (Pointer) fnCopy, NmtCategory.JFR)) {
+                        LibC.free(fnCopy);
+                        SubstrateJVM.getLogging().logJfrSystemError("Unable to add chunk filename to list during jfr emergency dump");
+                    } else {
+                        count++;
+                    }
                 }
             }
             closeDirectory();
@@ -324,6 +332,15 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
             }
         }
         NullableNativeMemory.free(copyBlock);
+    }
+
+    private void freeChunkFilenames(GrowableWordArray chunkFilenames) {
+        for (int i = 0; i < chunkFilenames.getSize(); i++) {
+            CCharPointer fn = (CCharPointer) ((Pointer) GrowableWordArrayAccess.get(chunkFilenames, i));
+            if (fn.isNonNull()) {
+                LibC.free(fn);
+            }
+        }
     }
 
     private boolean openDirectory() {

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/jfr/PosixJfrEmergencyDumpSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/jfr/PosixJfrEmergencyDumpSupport.java
@@ -109,7 +109,11 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
     @Override
     public void setRepositoryLocation(String dirText) {
         repositoryLocationBytes = dirText.getBytes(StandardCharsets.UTF_8);
-        openDirectoryWarning = "Unable to open repository " + dirText;
+        if (isRepositoryLocationTooLong(repositoryLocationBytes)) {
+            openDirectoryWarning = "Unable to open repository " + dirText + ". Repository path is too long.";
+        } else {
+            openDirectoryWarning = "Unable to open repository " + dirText;
+        }
     }
 
     /** This method is called during JFR initialization. */
@@ -123,7 +127,11 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
         }
 
         if (dumpPathBytes != null) {
-            openFileWarning = "Unable to create an emergency dump file at the location set by dumppath=" + new String(dumpPathBytes, StandardCharsets.UTF_8);
+            if (isDumpPathTooLong(dumpPathBytes)) {
+                openFileWarning = "Unable to create an emergency dump file at the location set by dumppath=" + new String(dumpPathBytes, StandardCharsets.UTF_8) + ". Dump path is too long.";
+            } else {
+                openFileWarning = "Unable to create an emergency dump file at the location set by dumppath=" + new String(dumpPathBytes, StandardCharsets.UTF_8);
+            }
         } else {
             openFileWarning = "Unable to create an emergency dump file. Dump path could not be set.";
         }
@@ -167,6 +175,9 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
      */
     @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+3/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp#L418-L431")
     private RawFileDescriptor createEmergencyChunkPath() {
+        if (isRepositoryLocationTooLong(repositoryLocationBytes)) {
+            return Word.nullPointer();
+        }
         clearPathBuffer();
         int idx = 0;
         idx = writeToPathBuffer(repositoryLocationBytes, idx);
@@ -205,14 +216,22 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
             return true;
         }
         // O_CREAT | O_RDWR and S_IREAD | S_IWRITE permissions
-        emergencyFd = getFileSupport().create(createEmergencyDumpPath(), FileCreationMode.CREATE, FileAccessMode.READ_WRITE);
+        emergencyFd = createEmergencyDumpFile();
         if (!getFileSupport().isValid(emergencyFd)) {
             SubstrateJVM.getLogging().logJfrWarning(openFileWarning);
             // Fallback. Try to create it in the current directory.
             dumpPathBytes = null;
-            emergencyFd = getFileSupport().create(createEmergencyDumpPath(), FileCreationMode.CREATE, FileAccessMode.READ_WRITE);
+            emergencyFd = createEmergencyDumpFile();
         }
         return getFileSupport().isValid(emergencyFd);
+    }
+
+    private RawFileDescriptor createEmergencyDumpFile() {
+        CCharPointer path = createEmergencyDumpPath();
+        if (path.isNull()) {
+            return Word.nullPointer();
+        }
+        return getFileSupport().create(path, FileCreationMode.CREATE, FileAccessMode.READ_WRITE);
     }
 
     @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+2/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp#L110-L129")
@@ -222,6 +241,9 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
 
         if (dumpPathBytes == null) {
             dumpPathBytes = cwdBytes;
+        }
+        if (isDumpPathTooLong(dumpPathBytes)) {
+            return Word.nullPointer();
         }
         if (dumpPathBytes != null) {
             idx = writeToPathBuffer(dumpPathBytes, idx);
@@ -346,7 +368,12 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
     }
 
     private boolean openDirectory() {
-        int fd = Fcntl.NoTransitions.restartableOpen(getRepositoryLocation(), O_RDONLY() | O_NOFOLLOW(), 0);
+        CCharPointer repositoryLocation = getRepositoryLocation();
+        if (repositoryLocation.isNull()) {
+            SubstrateJVM.getLogging().logJfrSystemError(openDirectoryWarning);
+            return false;
+        }
+        int fd = Fcntl.NoTransitions.restartableOpen(repositoryLocation, O_RDONLY() | O_NOFOLLOW(), 0);
         if (fd == -1) {
             return false;
         }
@@ -361,6 +388,9 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
     }
 
     private CCharPointer getRepositoryLocation() {
+        if (repositoryLocationBytes == null || isRepositoryLocationTooLong(repositoryLocationBytes)) {
+            return Word.nullPointer();
+        }
         clearPathBuffer();
         writeToPathBuffer(repositoryLocationBytes, 0);
         return getPathBuffer();
@@ -398,8 +428,13 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
             }
         }
 
+        CCharPointer chunkPath = fullyQualified(fn);
+        if (chunkPath.isNull()) {
+            return false;
+        }
+
         // Verify it can be opened and receive a valid file descriptor
-        RawFileDescriptor chunkFd = getFileSupport().open(fullyQualified(fn), FileAccessMode.READ_WRITE);
+        RawFileDescriptor chunkFd = getFileSupport().open(chunkPath, FileAccessMode.READ_WRITE);
         if (!getFileSupport().isValid(chunkFd)) {
             return false;
         }
@@ -420,6 +455,9 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
     @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+2/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp#L263-L273")
     private CCharPointer fullyQualified(CCharPointer fn) {
         long fnLength = SubstrateUtil.strlen(fn).rawValue();
+        if (repositoryLocationBytes == null || repositoryLocationBytes.length + 1L + fnLength >= JVM_MAXPATHLEN) {
+            return Word.nullPointer();
+        }
         int idx = 0;
 
         clearPathBuffer();
@@ -433,7 +471,7 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
         for (int i = 0; i < fnLength; i++) {
             getPathBuffer().write(idx++, fn.read(i));
         }
-        getPathBuffer().write(idx++, (byte) 0);
+        getPathBuffer().write(idx, (byte) 0);
         return getPathBuffer();
     }
 
@@ -451,6 +489,18 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
             getPathBuffer().write(idx++, bytes[i]);
         }
         return idx;
+    }
+
+    private static boolean isRepositoryLocationTooLong(byte[] repositoryLocation) {
+        return repositoryLocation != null && repositoryLocation.length + 1L + EMERGENCY_CHUNK_BYTES.length + CHUNKFILE_EXTENSION_BYTES.length >= JVM_MAXPATHLEN;
+    }
+
+    private boolean isDumpPathTooLong(byte[] dumpPath) {
+        return dumpPath != null && dumpPath.length + 1L + DUMP_FILE_PREFIX.length + getPidBytesLength() + CHUNKFILE_EXTENSION_BYTES.length >= JVM_MAXPATHLEN;
+    }
+
+    private int getPidBytesLength() {
+        return pidBytes != null ? pidBytes.length : Long.toString(ProcessHandle.current().pid()).getBytes(StandardCharsets.UTF_8).length;
     }
 
     static RawFileOperationSupport getFileSupport() {

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/jfr/PosixJfrEmergencyDumpSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/jfr/PosixJfrEmergencyDumpSupport.java
@@ -405,6 +405,7 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
         // Verify file size
         long chunkFileSize = getFileSupport().size(chunkFd);
         if (chunkFileSize < CHUNK_FILE_HEADER_SIZE) {
+            getFileSupport().close(chunkFd);
             return false;
         }
         getFileSupport().close(chunkFd);

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/jfr/PosixJfrEmergencyDumpSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/jfr/PosixJfrEmergencyDumpSupport.java
@@ -303,30 +303,32 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
 
         for (int i = 0; i < sortedChunkFilenames.getSize(); i++) {
             CCharPointer fn = (CCharPointer) ((Pointer) GrowableWordArrayAccess.get(sortedChunkFilenames, i));
-            RawFileDescriptor chunkFd = getFileSupport().open(fullyQualified(fn), FileAccessMode.READ_WRITE);
+            RawFileDescriptor chunkFd = getFileSupport().open(fullyQualified(fn), FileAccessMode.READ);
             if (getFileSupport().isValid(chunkFd)) {
 
                 // Read it's size
                 long chunkFileSize = getFileSupport().size(chunkFd);
                 long bytesRead = 0;
-                long bytesWritten = 0;
+                if (!getFileSupport().seek(chunkFd, 0)) {
+                    SubstrateJVM.getLogging().logJfrInfo("Unable to recover JFR data, seek failed.");
+                    getFileSupport().close(chunkFd);
+                    continue;
+                }
                 while (bytesRead < chunkFileSize) {
-                    // Start at beginning
-                    getFileSupport().seek(chunkFd, 0);
                     // Read from chunk file to copy block
                     long readResult = getFileSupport().read(chunkFd, copyBlock, Word.unsigned(blockSize));
-                    if (readResult < 0) { // -1 if read failed
-                        SubstrateJVM.getLogging().logJfrInfo("Unable to recover JFR data, read failed.");
+                    if (readResult <= 0) {
+                        if (readResult < 0) {
+                            SubstrateJVM.getLogging().logJfrInfo("Unable to recover JFR data, read failed.");
+                        }
                         break;
                     }
                     bytesRead += readResult;
-                    assert bytesRead - bytesWritten <= blockSize;
                     // Write from copy block to dump file
-                    if (!getFileSupport().write(emergencyFd, copyBlock, Word.unsigned(bytesRead - bytesWritten))) {
+                    if (!getFileSupport().write(emergencyFd, copyBlock, Word.unsigned(readResult))) {
                         SubstrateJVM.getLogging().logJfrInfo("Unable to recover JFR data, write failed.");
                         break;
                     }
-                    bytesWritten = bytesRead;
                 }
                 getFileSupport().close(chunkFd);
             }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/jfr/PosixJfrEmergencyDumpSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/jfr/PosixJfrEmergencyDumpSupport.java
@@ -146,12 +146,16 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
     @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+3/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp#L433-L445")
     public RawFileDescriptor chunkPath() {
         if (repositoryLocationBytes == null) {
-            openEmergencyDumpFile();
+            if (!openEmergencyDumpFile()) {
+                return Word.nullPointer();
+            }
             /*
              * We can directly use the emergency dump file name as the new chunk since there are no
              * other chunk files.
              */
-            return emergencyFd;
+            RawFileDescriptor fd = emergencyFd;
+            emergencyFd = Word.nullPointer();
+            return fd;
         }
         return createEmergencyChunkPath();
     }
@@ -176,6 +180,9 @@ public class PosixJfrEmergencyDumpSupport implements com.oracle.svm.core.jfr.Jfr
     @Override
     @BasedOnJDKFile("https://github.com/openjdk/jdk/blob/jdk-26+2/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp#L409-L416")
     public void onVmError() {
+        if (repositoryLocationBytes == null) {
+            return;
+        }
         if (openEmergencyDumpFile()) {
             GrowableWordArray sortedChunkFilenames = StackValue.get(GrowableWordArray.class);
             GrowableWordArrayAccess.initialize(sortedChunkFilenames);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/UninterruptibleUtils.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/UninterruptibleUtils.java
@@ -591,6 +591,21 @@ public class UninterruptibleUtils {
             }
         }
 
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public static boolean isHighSurrogate(char ch) {
+            return ch >= 0xD800 && ch <= 0xDBFF;
+        }
+
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public static boolean isLowSurrogate(char ch) {
+            return ch >= 0xDC00 && ch <= 0xDFFF;
+        }
+
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public static int toCodePoint(char high, char low) {
+            return ((high - 0xD800) << 10) + (low - 0xDC00) + 0x10000;
+        }
+
         /**
          * Write a char in modified UTF8 format into the buffer.
          */
@@ -689,13 +704,13 @@ public class UninterruptibleUtils {
                 if (replacer != null) {
                     ch = replacer.replace(ch);
                 }
-                if (java.lang.Character.isHighSurrogate(ch) && index + 1 < string.length()) {
+                if (isHighSurrogate(ch) && index + 1 < string.length()) {
                     char low = charAt(string, index + 1);
                     if (replacer != null) {
                         low = replacer.replace(low);
                     }
-                    if (java.lang.Character.isLowSurrogate(low)) {
-                        result += utf8Length(java.lang.Character.toCodePoint(ch, low));
+                    if (isLowSurrogate(low)) {
+                        result += utf8Length(toCodePoint(ch, low));
                         index++;
                         continue;
                     }
@@ -765,13 +780,13 @@ public class UninterruptibleUtils {
                 if (replacer != null) {
                     ch = replacer.replace(ch);
                 }
-                if (java.lang.Character.isHighSurrogate(ch) && index + 1 < stringLength) {
+                if (isHighSurrogate(ch) && index + 1 < stringLength) {
                     char low = charAt(string, index + 1);
                     if (replacer != null) {
                         low = replacer.replace(low);
                     }
-                    if (java.lang.Character.isLowSurrogate(low)) {
-                        pos = writeUTF8(pos, java.lang.Character.toCodePoint(ch, low));
+                    if (isLowSurrogate(low)) {
+                        pos = writeUTF8(pos, toCodePoint(ch, low));
                         index++;
                         continue;
                     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/UninterruptibleUtils.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/UninterruptibleUtils.java
@@ -562,6 +562,36 @@ public class UninterruptibleUtils {
         }
 
         /**
+         * Gets the number of bytes for a char in UTF-8 format.
+         */
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public static int utf8Length(char c) {
+            if (c <= 0x007F) {
+                return 1;
+            } else if (c <= 0x07FF) {
+                return 2;
+            } else {
+                return 3;
+            }
+        }
+
+        /**
+         * Gets the number of bytes for a code point in UTF-8 format.
+         */
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public static int utf8Length(int codePoint) {
+            if (codePoint <= 0x007F) {
+                return 1;
+            } else if (codePoint <= 0x07FF) {
+                return 2;
+            } else if (codePoint <= 0xFFFF) {
+                return 3;
+            } else {
+                return 4;
+            }
+        }
+
+        /**
          * Write a char in modified UTF8 format into the buffer.
          */
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
@@ -579,6 +609,42 @@ public class UninterruptibleUtils {
                 pos.writeByte(1, (byte) (0x80 | ((c >> 6) & 0x3F)));
                 pos.writeByte(2, (byte) (0x80 | (c & 0x3F)));
                 pos = pos.add(3);
+            }
+            return pos;
+        }
+
+        /**
+         * Write a char in UTF-8 format into the buffer.
+         */
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public static Pointer writeUTF8(Pointer buffer, char c) {
+            return writeUTF8(buffer, (int) c);
+        }
+
+        /**
+         * Write a code point in UTF-8 format into the buffer.
+         */
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public static Pointer writeUTF8(Pointer buffer, int codePoint) {
+            Pointer pos = buffer;
+            if (codePoint <= 0x007F) {
+                pos.writeByte(0, (byte) codePoint);
+                pos = pos.add(1);
+            } else if (codePoint <= 0x07FF) {
+                pos.writeByte(0, (byte) (0xC0 | (codePoint >> 6)));
+                pos.writeByte(1, (byte) (0x80 | (codePoint & 0x3F)));
+                pos = pos.add(2);
+            } else if (codePoint <= 0xFFFF) {
+                pos.writeByte(0, (byte) (0xE0 | (codePoint >> 12)));
+                pos.writeByte(1, (byte) (0x80 | ((codePoint >> 6) & 0x3F)));
+                pos.writeByte(2, (byte) (0x80 | (codePoint & 0x3F)));
+                pos = pos.add(3);
+            } else {
+                pos.writeByte(0, (byte) (0xF0 | (codePoint >> 18)));
+                pos.writeByte(1, (byte) (0x80 | ((codePoint >> 12) & 0x3F)));
+                pos.writeByte(2, (byte) (0x80 | ((codePoint >> 6) & 0x3F)));
+                pos.writeByte(3, (byte) (0x80 | (codePoint & 0x3F)));
+                pos = pos.add(4);
             }
             return pos;
         }
@@ -602,6 +668,39 @@ public class UninterruptibleUtils {
                     ch = replacer.replace(ch);
                 }
                 result += modifiedUTF8Length(ch);
+            }
+
+            return result + (addNullTerminator ? 1 : 0);
+        }
+
+        /**
+         * Gets the length of {@code string} when encoded using UTF-8.
+         */
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public static int utf8Length(java.lang.String string, boolean addNullTerminator) {
+            return utf8Length(string, addNullTerminator, null);
+        }
+
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public static int utf8Length(java.lang.String string, boolean addNullTerminator, CharReplacer replacer) {
+            int result = 0;
+            for (int index = 0; index < string.length(); index++) {
+                char ch = charAt(string, index);
+                if (replacer != null) {
+                    ch = replacer.replace(ch);
+                }
+                if (java.lang.Character.isHighSurrogate(ch) && index + 1 < string.length()) {
+                    char low = charAt(string, index + 1);
+                    if (replacer != null) {
+                        low = replacer.replace(low);
+                    }
+                    if (java.lang.Character.isLowSurrogate(low)) {
+                        result += utf8Length(java.lang.Character.toCodePoint(ch, low));
+                        index++;
+                        continue;
+                    }
+                }
+                result += utf8Length(ch);
             }
 
             return result + (addNullTerminator ? 1 : 0);
@@ -633,6 +732,51 @@ public class UninterruptibleUtils {
                     ch = replacer.replace(ch);
                 }
                 pos = writeModifiedUTF8(pos, ch);
+            }
+
+            if (addNullTerminator) {
+                pos.writeByte(0, (byte) 0);
+                pos = pos.add(1);
+            }
+            VMError.guarantee(pos.belowOrEqual(bufferEnd), "Must not write out of bounds.");
+            return pos;
+        }
+
+        /**
+         * Writes the encoded {@code string} into the given {@code buffer} using UTF-8.
+         *
+         * @return pointer on new position in buffer.
+         */
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public static Pointer toUTF8(java.lang.String string, Pointer buffer, Pointer bufferEnd, boolean addNullTerminator) {
+            return toUTF8(string, buffer, bufferEnd, addNullTerminator, null);
+        }
+
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public static Pointer toUTF8(java.lang.String string, Pointer buffer, Pointer bufferEnd, boolean addNullTerminator, CharReplacer replacer) {
+            return toUTF8(string, string.length(), buffer, bufferEnd, addNullTerminator, replacer);
+        }
+
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public static Pointer toUTF8(java.lang.String string, int stringLength, Pointer buffer, Pointer bufferEnd, boolean addNullTerminator, CharReplacer replacer) {
+            Pointer pos = buffer;
+            for (int index = 0; index < stringLength; index++) {
+                char ch = charAt(string, index);
+                if (replacer != null) {
+                    ch = replacer.replace(ch);
+                }
+                if (java.lang.Character.isHighSurrogate(ch) && index + 1 < stringLength) {
+                    char low = charAt(string, index + 1);
+                    if (replacer != null) {
+                        low = replacer.replace(low);
+                    }
+                    if (java.lang.Character.isLowSurrogate(low)) {
+                        pos = writeUTF8(pos, java.lang.Character.toCodePoint(ch, low));
+                        index++;
+                        continue;
+                    }
+                }
+                pos = writeUTF8(pos, ch);
             }
 
             if (addNullTerminator) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrChunkFileWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrChunkFileWriter.java
@@ -26,6 +26,7 @@ package com.oracle.svm.core.jfr;
 
 import static com.oracle.svm.core.jfr.JfrThreadLocal.getJavaBufferList;
 import static com.oracle.svm.core.jfr.JfrThreadLocal.getNativeBufferList;
+import static com.oracle.svm.core.heap.RestrictHeapAccess.Access.NO_ALLOCATION;
 import static com.oracle.svm.guest.staging.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
 
 import org.graalvm.nativeimage.c.struct.SizeOf;
@@ -37,6 +38,7 @@ import org.graalvm.word.Pointer;
 import org.graalvm.word.UnsignedWord;
 import org.graalvm.word.impl.Word;
 
+import com.oracle.svm.core.heap.RestrictHeapAccess;
 import com.oracle.svm.core.heap.VMOperationInfos;
 import com.oracle.svm.core.jdk.UninterruptibleUtils;
 import com.oracle.svm.core.jfr.oldobject.JfrOldObjectRepository;
@@ -49,6 +51,7 @@ import com.oracle.svm.core.os.RawFileOperationSupport.FileAccessMode;
 import com.oracle.svm.core.os.RawFileOperationSupport.FileCreationMode;
 import com.oracle.svm.core.os.RawFileOperationSupport.RawFileDescriptor;
 import com.oracle.svm.core.sampler.SamplerBuffersAccess;
+import com.oracle.svm.core.thread.JavaVMOperation;
 import com.oracle.svm.core.thread.NativeVMOperation;
 import com.oracle.svm.core.thread.NativeVMOperationData;
 import com.oracle.svm.core.thread.RecurringCallbackSupport;
@@ -82,6 +85,7 @@ public final class JfrChunkFileWriter implements JfrChunkWriter {
     private static final short FLAG_CHUNK_FINAL = 0b10;
 
     private final JfrChangeEpochOperation epochChangeOp;
+    private PreparePreviousEpochSnapshotOperation prepareSnapshotOp;
     private final VMMutex lock;
     private final JfrGlobalMemory globalMemory;
     private final JfrMetadata metadata;
@@ -123,6 +127,7 @@ public final class JfrChunkFileWriter implements JfrChunkWriter {
     @Override
     public void initialize(long maxChunkSize) {
         this.notificationThreshold = maxChunkSize;
+        prepareSnapshotOp = new PreparePreviousEpochSnapshotOperation();
     }
 
     @Override
@@ -237,6 +242,8 @@ public final class JfrChunkFileWriter implements JfrChunkWriter {
         NativeVMOperationData data = StackValue.get(size);
         UnmanagedMemoryUtil.fill((Pointer) data, Word.unsigned(size), (byte) 0);
         epochChangeOp.enqueue(data);
+        assert prepareSnapshotOp != null;
+        prepareSnapshotOp.enqueue();
 
         /*
          * After changing the epoch, all subsequently triggered JFR events will be recorded into the
@@ -733,6 +740,18 @@ public final class JfrChunkFileWriter implements JfrChunkWriter {
         private static void processSamplerBuffers0() {
             SamplerBuffersAccess.processActiveBuffers();
             SamplerBuffersAccess.processFullBuffers(false);
+        }
+    }
+
+    private static final class PreparePreviousEpochSnapshotOperation extends JavaVMOperation {
+        PreparePreviousEpochSnapshotOperation() {
+            super(VMOperationInfos.get(PreparePreviousEpochSnapshotOperation.class, "JFR prepare previous epoch snapshot", SystemEffect.SAFEPOINT));
+        }
+
+        @Override
+        @RestrictHeapAccess(access = NO_ALLOCATION, reason = "Used on OOME for emergency dumps")
+        protected void operate() {
+            SubstrateJVM.getTypeRepository().preparePreviousEpochSnapshot();
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrChunkFileWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrChunkFileWriter.java
@@ -534,7 +534,7 @@ public final class JfrChunkFileWriter implements JfrChunkWriter {
         } else {
             getFileSupport().writeByte(fd, StringEncoding.UTF8_BYTE_ARRAY.getValue());
 
-            int length = UninterruptibleUtils.String.modifiedUTF8Length(str, false);
+            int length = UninterruptibleUtils.String.utf8Length(str, false);
             writeCompressedInt(length);
             int bufferSize = 64;
             Pointer buffer = StackValue.get(bufferSize);
@@ -546,13 +546,26 @@ public final class JfrChunkFileWriter implements JfrChunkWriter {
                 Pointer pos = buffer;
                 while (charsWritten < str.length()) {
                     char ch = UninterruptibleUtils.String.charAt(str, charsWritten);
-                    int nextCharSize = UninterruptibleUtils.String.modifiedUTF8Length(ch);
+                    int nextCharSize = UninterruptibleUtils.String.utf8Length(ch);
+                    int charsConsumed = 1;
+                    if (Character.isHighSurrogate(ch) && charsWritten + 1 < str.length()) {
+                        char low = UninterruptibleUtils.String.charAt(str, charsWritten + 1);
+                        if (Character.isLowSurrogate(low)) {
+                            nextCharSize = UninterruptibleUtils.String.utf8Length(Character.toCodePoint(ch, low));
+                            charsConsumed = 2;
+                        }
+                    }
                     if (pos.add(nextCharSize).aboveThan(bufferEnd)) {
                         // buffer is too full to add the next char
                         break;
                     }
-                    pos = UninterruptibleUtils.String.writeModifiedUTF8(pos, ch);
-                    charsWritten++;
+                    if (charsConsumed == 2) {
+                        char low = UninterruptibleUtils.String.charAt(str, charsWritten + 1);
+                        pos = UninterruptibleUtils.String.writeUTF8(pos, Character.toCodePoint(ch, low));
+                    } else {
+                        pos = UninterruptibleUtils.String.writeUTF8(pos, ch);
+                    }
+                    charsWritten += charsConsumed;
                 }
                 // Write the contents of the buffer to disk
                 UnsignedWord bytesToDisk = pos.subtract(buffer);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrChunkFileWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrChunkFileWriter.java
@@ -548,10 +548,10 @@ public final class JfrChunkFileWriter implements JfrChunkWriter {
                     char ch = UninterruptibleUtils.String.charAt(str, charsWritten);
                     int nextCharSize = UninterruptibleUtils.String.utf8Length(ch);
                     int charsConsumed = 1;
-                    if (Character.isHighSurrogate(ch) && charsWritten + 1 < str.length()) {
+                    if (UninterruptibleUtils.String.isHighSurrogate(ch) && charsWritten + 1 < str.length()) {
                         char low = UninterruptibleUtils.String.charAt(str, charsWritten + 1);
-                        if (Character.isLowSurrogate(low)) {
-                            nextCharSize = UninterruptibleUtils.String.utf8Length(Character.toCodePoint(ch, low));
+                        if (UninterruptibleUtils.String.isLowSurrogate(low)) {
+                            nextCharSize = UninterruptibleUtils.String.utf8Length(UninterruptibleUtils.String.toCodePoint(ch, low));
                             charsConsumed = 2;
                         }
                     }
@@ -561,7 +561,7 @@ public final class JfrChunkFileWriter implements JfrChunkWriter {
                     }
                     if (charsConsumed == 2) {
                         char low = UninterruptibleUtils.String.charAt(str, charsWritten + 1);
-                        pos = UninterruptibleUtils.String.writeUTF8(pos, Character.toCodePoint(ch, low));
+                        pos = UninterruptibleUtils.String.writeUTF8(pos, UninterruptibleUtils.String.toCodePoint(ch, low));
                     } else {
                         pos = UninterruptibleUtils.String.writeUTF8(pos, ch);
                     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrNativeEventWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrNativeEventWriter.java
@@ -213,11 +213,11 @@ public final class JfrNativeEventWriter {
         } else if (string.isEmpty()) {
             putByte(data, JfrChunkFileWriter.StringEncoding.EMPTY_STRING.getValue());
         } else {
-            int mUTF8Length = UninterruptibleUtils.String.modifiedUTF8Length(string, false, replacer);
+            int utf8Length = UninterruptibleUtils.String.utf8Length(string, false, replacer);
             putByte(data, JfrChunkFileWriter.StringEncoding.UTF8_BYTE_ARRAY.getValue());
-            putInt(data, mUTF8Length);
-            if (ensureSize(data, mUTF8Length)) {
-                Pointer newPosition = UninterruptibleUtils.String.toModifiedUTF8(string, data.getCurrentPos(), data.getEndPos(), false, replacer);
+            putInt(data, utf8Length);
+            if (ensureSize(data, utf8Length)) {
+                Pointer newPosition = UninterruptibleUtils.String.toUTF8(string, data.getCurrentPos(), data.getEndPos(), false, replacer);
                 data.setCurrentPos(newPosition);
             }
         }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrSymbolRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrSymbolRepository.java
@@ -147,7 +147,7 @@ public class JfrSymbolRepository implements JfrRepository {
             JfrNativeEventWriter.putLong(data, newEntry.getId());
             JfrNativeEventWriter.putString(data, newEntry.getModifiedUTF8(), (int) newEntry.getLength().rawValue());
             if (!JfrNativeEventWriter.commit(data)) {
-                NullableNativeMemory.free(symbol.getModifiedUTF8());
+                epochData.table.remove(symbol);
                 return 0L;
             }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrSymbolRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrSymbolRepository.java
@@ -88,12 +88,12 @@ public class JfrSymbolRepository implements JfrRepository {
         }
 
         assert Heap.getHeap().isInImageHeap(imageHeapString);
-        int length = UninterruptibleUtils.String.modifiedUTF8Length(imageHeapString, false);
+        int length = UninterruptibleUtils.String.utf8Length(imageHeapString, false, replaceDotWithSlash ? dotWithSlash : null);
         Pointer buffer = NullableNativeMemory.malloc(length, NmtCategory.JFR);
         if (buffer.isNull()) {
             return 0;
         }
-        UninterruptibleUtils.String.toModifiedUTF8(imageHeapString, imageHeapString.length(), buffer, buffer.add(length), false, replaceDotWithSlash ? dotWithSlash : null);
+        UninterruptibleUtils.String.toUTF8(imageHeapString, imageHeapString.length(), buffer, buffer.add(length), false, replaceDotWithSlash ? dotWithSlash : null);
 
         return getSymbolId(buffer, Word.unsigned(length), previousEpoch);
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrSymbolRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrSymbolRepository.java
@@ -83,7 +83,7 @@ public class JfrSymbolRepository implements JfrRepository {
 
     @Uninterruptible(reason = "Locking without transition and result is only valid until epoch changes.", callerMustBe = true)
     public long getSymbolId(String imageHeapString, boolean previousEpoch, boolean replaceDotWithSlash) {
-        if (imageHeapString == null || imageHeapString.isEmpty()) {
+        if (imageHeapString == null) {
             return 0;
         }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,89 +26,86 @@ package com.oracle.svm.core.jfr;
 
 import static com.oracle.svm.guest.staging.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
 
-import com.oracle.svm.core.UnmanagedMemoryUtil;
-import com.oracle.svm.core.headers.LibC;
-import com.oracle.svm.core.jdk.UninterruptibleUtils;
-import org.graalvm.nativeimage.c.struct.RawField;
-import org.graalvm.nativeimage.c.struct.RawStructure;
-import com.oracle.svm.core.c.struct.PinnedObjectField;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
 
+import org.graalvm.collections.EconomicSet;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
-import org.graalvm.word.Pointer;
-import org.graalvm.nativeimage.c.struct.SizeOf;
 import org.graalvm.nativeimage.StackValue;
+import org.graalvm.nativeimage.c.struct.RawField;
+import org.graalvm.nativeimage.c.struct.RawStructure;
+import org.graalvm.nativeimage.c.struct.SizeOf;
+import org.graalvm.word.Pointer;
 import org.graalvm.word.UnsignedWord;
 import org.graalvm.word.impl.Word;
 
+import com.oracle.svm.core.UnmanagedMemoryUtil;
+import com.oracle.svm.core.c.struct.PinnedObjectField;
 import com.oracle.svm.core.collections.AbstractUninterruptibleHashtable;
 import com.oracle.svm.core.collections.UninterruptibleEntry;
+import com.oracle.svm.core.headers.LibC;
 import com.oracle.svm.core.hub.DynamicHub;
 import com.oracle.svm.core.hub.LayoutEncoding;
-import com.oracle.svm.guest.staging.Uninterruptible;
+import com.oracle.svm.core.jdk.UninterruptibleUtils;
 import com.oracle.svm.core.jfr.traceid.JfrTraceId;
 import com.oracle.svm.core.jfr.traceid.JfrTraceIdEpoch;
 import com.oracle.svm.core.locks.VMMutex;
-import com.oracle.svm.core.nmt.NmtCategory;
 import com.oracle.svm.core.memory.NullableNativeMemory;
+import com.oracle.svm.core.nmt.NmtCategory;
+import com.oracle.svm.guest.staging.Uninterruptible;
 
 /**
- * Repository that collects and writes used classes, packages, modules, and classloaders. There are
- * three kinds of tables used by this class: {@code epochTypeData*}, {@code flushed*}, and
- * {@link #typeInfo}. The {@code flushed*} tables record which classes have already been flushed to
- * disk. The {@code epochTypeData*} tables hold classes that have yet to be flushed as well as
- * classes that are already flushed (they are written by threads emitting events). The
- * {@link #typeInfo} table is derived at flushpoints by using the {@code epochTypeData*} and
- * {@code flushed*} tables to determine the set of classes that have yet to be flushed.
+ * Repository that collects and writes used classes, packages, modules, and classloaders.
  *
- * Unlike other JFR repositories, there are no epoch data buffers that require lock protection.
- * Similar to other constant repositories, writes/reads to the current {@code epochData} are allowed
- * to race at flushpoints. There is no risk of separating events from constant data due to the write
- * order (constants before events during emission, and events before constants during flush). The
- * {@code epochData} tables are only cleared at rotation safepoints.
+ * <p>
+ * There are two separate paths:
+ * <ul>
+ * <li>Flush checkpoints use transient Java-side collections under the chunk writer lock.</li>
+ * <li>Chunk close uses a native snapshot built under the chunk writer lock at the epoch-change
+ * safepoint so that
+ * {@code write(false)} stays allocation-free in the OOME path.</li>
+ * </ul>
  */
 public class JfrTypeRepository implements JfrRepository {
     private static final String BOOTSTRAP_NAME = "bootstrap";
-    // The following tables are only used by the flushing/rotating thread.
-    private final JfrClassInfoTable flushedClasses;
-    private final JfrPackageInfoTable flushedPackages;
-    private final JfrModuleInfoTable flushedModules;
-    private final JfrClassLoaderInfoTable flushedClassLoaders;
-    private final TypeInfo typeInfo;
+    private static final String EMPTY_NAME = "";
 
-    /*
-     * epochTypeData tables are written by threads emitting events and read from the
-     * flushing/rotating thread. Their purpose is to lazily collect tagged JFR classes, which are
-     * later serialized during flush/rotation.
-     */
+    private final EconomicSet<Class<?>> flushedClasses;
+    private final JfrPackageTable flushedPackages;
+    private final Map<Module, Long> flushedModules;
+    private final Map<ClassLoader, Long> flushedClassLoaders;
+    private final PreviousEpochTypeSnapshot previousEpochSnapshot;
+
     private final JfrClassInfoTable epochTypeData0;
     private final JfrClassInfoTable epochTypeData1;
     private final VMMutex classIdMutex;
 
     private final UninterruptibleUtils.CharReplacer dotWithSlash;
-    private long currentPackageId = 0;
-    private long currentModuleId = 0;
-    private long currentClassLoaderId = 0;
+    private long currentPackageId;
+    private long currentModuleId;
+    private long currentClassLoaderId;
 
     @Platforms(Platform.HOSTED_ONLY.class)
     public JfrTypeRepository() {
-        flushedClasses = new JfrClassInfoTable();
-        flushedPackages = new JfrPackageInfoTable();
-        flushedModules = new JfrModuleInfoTable();
-        flushedClassLoaders = new JfrClassLoaderInfoTable();
-
-        typeInfo = new TypeInfo();
-        dotWithSlash = new ReplaceDotWithSlash();
-        classIdMutex = new VMMutex("jfrTypeRepositoryClassId");
+        flushedClasses = EconomicSet.create();
+        flushedPackages = new JfrPackageTable();
+        flushedModules = new IdentityHashMap<>();
+        flushedClassLoaders = new IdentityHashMap<>();
+        previousEpochSnapshot = new PreviousEpochTypeSnapshot();
 
         epochTypeData0 = new JfrClassInfoTable();
         epochTypeData1 = new JfrClassInfoTable();
+        classIdMutex = new VMMutex("jfrTypeRepositoryClassId");
+        dotWithSlash = new ReplaceDotWithSlash();
     }
 
     public void teardown() {
         clearEpochData();
         getEpochData(false).clear();
-        typeInfo.teardown();
+        previousEpochSnapshot.teardown();
+        flushedPackages.teardown();
     }
 
     @Uninterruptible(reason = "Result is only valid until epoch changes.")
@@ -117,461 +114,613 @@ public class JfrTypeRepository implements JfrRepository {
         return epoch ? epochTypeData0 : epochTypeData1;
     }
 
-    @Uninterruptible(reason = "Result is only valid until epoch changes.", callerMustBe = true)
+    @Uninterruptible(reason = "Locking without transition and result is only valid until epoch changes.", callerMustBe = true)
     public long getClassId(Class<?> clazz) {
-        JfrClassInfoTable classInfoTable = getEpochData(false);
+        long classId = JfrTraceId.getTraceId(clazz);
         ClassInfoRaw classInfoRaw = StackValue.get(ClassInfoRaw.class);
-        classInfoRaw.setId(JfrTraceId.getTraceId(clazz));
-        classInfoRaw.setHash(getHash(clazz.getName()));
-        classInfoRaw.setName(clazz.getName());
-        classInfoRaw.setInstance(clazz);
+        classInfoRaw.setId(classId);
+        classInfoRaw.setHash(getIdHash(classId));
+        classInfoRaw.setClazz(clazz);
+
         classIdMutex.lockNoTransition();
         try {
-            if (classInfoTable.getOrPut(classInfoRaw).isNull()) {
+            if (getEpochData(false).getOrPut(classInfoRaw).isNull()) {
                 return 0L;
             }
         } finally {
             classIdMutex.unlock();
         }
-
         return JfrTraceId.load(clazz);
+    }
+
+    public void preparePreviousEpochSnapshot() {
+        previousEpochSnapshot.reset();
+        buildPreviousEpochSnapshot();
     }
 
     @Override
     public int write(JfrChunkWriter writer, boolean flushpoint) {
-        typeInfo.reset();
-        collectTypeInfo(flushpoint);
-        int count = writeClasses(writer, flushpoint);
-        count += writePackages(writer, flushpoint);
-        count += writeModules(writer, flushpoint);
-        count += writeClassLoaders(writer, flushpoint);
         if (flushpoint) {
-            flushedClasses.putAll(typeInfo.classes);
-            flushedPackages.putAll(typeInfo.packages);
-            flushedModules.putAll(typeInfo.modules);
-            flushedClassLoaders.putAll(typeInfo.classLoaders);
-        } else {
-            clearEpochData();
+            TypeInfo typeInfo = collectCurrentTypeInfo();
+            int count = writeClasses(writer, typeInfo, true);
+            count += writePackages(writer, typeInfo, true);
+            count += writeModules(writer, typeInfo, true);
+            count += writeClassLoaders(writer, typeInfo, true);
+
+            if (count != 0) {
+                flushedClasses.addAll(typeInfo.classes);
+                flushedModules.putAll(typeInfo.modules);
+                flushedClassLoaders.putAll(typeInfo.classLoaders);
+                flushedPackages.putAll(typeInfo, this);
+            }
+            return count;
         }
+
+        int count = writePreviousEpochSnapshot(writer);
+        clearEpochData();
         return count;
     }
 
-    /**
-     * Visit all used classes, and collect their packages, modules, classloaders and possibly
-     * referenced classes.
-     *
-     * This method does not need to be marked uninterruptible since the epoch cannot change while
-     * the chunkwriter lock is held.
-     */
-    private void collectTypeInfo(boolean flushpoint) {
-        JfrClassInfoTable classInfoTable = getEpochData(!flushpoint);
-        ClassInfoRaw[] table = (ClassInfoRaw[]) classInfoTable.getTable();
-
+    private TypeInfo collectCurrentTypeInfo() {
+        TypeInfo typeInfo = new TypeInfo();
+        ClassInfoRaw[] table = (ClassInfoRaw[]) getEpochData(false).getTable();
         for (int i = 0; i < table.length; i++) {
             ClassInfoRaw entry = table[i];
             while (entry.isNonNull()) {
-                Class<?> clazz = entry.getInstance();
+                Class<?> clazz = entry.getClazz();
                 assert DynamicHub.fromClass(clazz).isLoaded();
-                if (flushpoint) {
-                    /*
-                     * Must check the bit is set since we don't clear the epoch data tables until
-                     * safepoint.
-                     */
-                    if (JfrTraceId.isUsedCurrentEpoch(clazz)) {
-                        visitClass(clazz);
-                    }
-                } else {
-                    if (JfrTraceId.isUsedPreviousEpoch(clazz)) {
-                        JfrTraceId.clearUsedPreviousEpoch(clazz);
-                        visitClass(clazz);
-                    }
+                if (JfrTraceId.isUsedCurrentEpoch(clazz)) {
+                    visitClass(typeInfo, clazz);
+                }
+                entry = entry.getNext();
+            }
+        }
+        return typeInfo;
+    }
+
+    private void buildPreviousEpochSnapshot() {
+        ClassInfoRaw[] table = (ClassInfoRaw[]) getEpochData(true).getTable();
+        for (int i = 0; i < table.length; i++) {
+            ClassInfoRaw entry = table[i];
+            while (entry.isNonNull()) {
+                Class<?> clazz = entry.getClazz();
+                assert DynamicHub.fromClass(clazz).isLoaded();
+                if (JfrTraceId.isUsedPreviousEpoch(clazz)) {
+                    JfrTraceId.clearUsedPreviousEpoch(clazz);
+                    visitClass(previousEpochSnapshot, clazz);
                 }
                 entry = entry.getNext();
             }
         }
     }
 
-    private void visitClass(Class<?> clazz) {
-        if (clazz != null && addClass(clazz)) {
-            visitClassLoader(clazz.getClassLoader());
-            visitPackage(clazz);
-            visitClass(clazz.getSuperclass());
+    private void visitClass(TypeInfo typeInfo, Class<?> clazz) {
+        if (clazz != null && addClass(typeInfo, clazz)) {
+            visitClassLoader(typeInfo, clazz.getClassLoader());
+            visitPackage(typeInfo, clazz.getPackage(), clazz.getModule());
+            visitClass(typeInfo, clazz.getSuperclass());
         }
     }
 
-    private void visitPackage(Class<?> clazz) {
-        if (addPackage(clazz)) {
-            visitModule(clazz);
+    private void visitPackage(TypeInfo typeInfo, Package pkg, Module module) {
+        if (pkg != null && addPackage(typeInfo, pkg, module)) {
+            visitModule(typeInfo, module);
         }
     }
 
-    private void visitModule(Class<?> clazz) {
-        Module module = clazz.getModule();
-        if (module != null && addModule(module)) {
-            visitClassLoader(module.getClassLoader());
+    private void visitModule(TypeInfo typeInfo, Module module) {
+        if (module != null && addModule(typeInfo, module)) {
+            visitClassLoader(typeInfo, module.getClassLoader());
         }
     }
 
-    private void visitClassLoader(ClassLoader classLoader) {
-        // The null class-loader is serialized as the "bootstrap" class-loader.
-        if (addClassLoader(classLoader)) {
-            if (classLoader != null) {
-                visitClass(classLoader.getClass());
-            }
+    private void visitClassLoader(TypeInfo typeInfo, ClassLoader classLoader) {
+        if (addClassLoader(typeInfo, classLoader) && classLoader != null) {
+            visitClass(typeInfo, classLoader.getClass());
         }
     }
 
-    private int writeClasses(JfrChunkWriter writer, boolean flushpoint) {
-        int size = typeInfo.classes.getSize();
-        ClassInfoRaw[] table = (ClassInfoRaw[]) typeInfo.classes.getTable();
-        if (size == 0) {
+    private void visitClass(PreviousEpochTypeSnapshot snapshot, Class<?> clazz) {
+        if (clazz != null && addClass(snapshot, clazz)) {
+            visitClassLoader(snapshot, clazz.getClassLoader());
+            visitClass(snapshot, clazz.getSuperclass());
+        }
+    }
+
+    private void visitClassLoader(PreviousEpochTypeSnapshot snapshot, ClassLoader classLoader) {
+        if (getClassLoaderId(snapshot, classLoader) != 0L && classLoader != null) {
+            visitClass(snapshot, classLoader.getClass());
+        }
+    }
+
+    private int writeClasses(JfrChunkWriter writer, TypeInfo typeInfo, boolean flushpoint) {
+        if (typeInfo.classes.isEmpty()) {
             return EMPTY;
         }
         writer.writeCompressedLong(JfrType.Class.getId());
-        writer.writeCompressedInt(size);
-
-        // Nested loops since the visitor pattern may allocate.
-        for (int i = 0; i < table.length; i++) {
-            ClassInfoRaw entry = table[i];
-            while (entry.isNonNull()) {
-                writeClass(writer, entry, flushpoint);
-                entry = entry.getNext();
-            }
+        writer.writeCompressedInt(typeInfo.classes.size());
+        for (Class<?> clazz : typeInfo.classes) {
+            writeClass(typeInfo, writer, clazz, flushpoint);
         }
         return NON_EMPTY;
     }
 
-    private void writeClass(JfrChunkWriter writer, ClassInfoRaw classInfoRaw, boolean flushpoint) {
-        assert classInfoRaw.getHash() != 0;
-        Class<?> clazz = classInfoRaw.getInstance();
-        PackageInfoRaw packageInfoRaw = StackValue.get(PackageInfoRaw.class);
-        packageInfoRaw.setHasModule(clazz.getModule() != null);
-        packageInfoRaw.setModule(clazz.getModule());
-        setPackageNameAndLength(clazz, packageInfoRaw);
-        packageInfoRaw.setHash(getHash(packageInfoRaw));
-
-        writer.writeCompressedLong(classInfoRaw.getId());
-        writer.writeCompressedLong(getClassLoaderId(clazz.getClassLoader()));
+    private void writeClass(TypeInfo typeInfo, JfrChunkWriter writer, Class<?> clazz, boolean flushpoint) {
+        writer.writeCompressedLong(JfrTraceId.getTraceId(clazz));
+        writer.writeCompressedLong(getClassLoaderId(typeInfo, clazz.getClassLoader()));
         writer.writeCompressedLong(getSymbolId(writer, clazz.getName(), flushpoint, true));
-        writer.writeCompressedLong(getPackageId(packageInfoRaw));
+        writer.writeCompressedLong(getPackageId(typeInfo, clazz));
         writer.writeCompressedLong(clazz.getModifiers());
         writer.writeBoolean(clazz.isHidden());
+    }
 
-        // We no longer need the buffer.
-        if (packageInfoRaw.getModifiedUTF8Name().isNonNull()) {
-            NullableNativeMemory.free(packageInfoRaw.getModifiedUTF8Name());
+    @Uninterruptible(reason = "Needed for JfrSymbolRepository.getSymbolId().")
+    private long getSymbolId(JfrChunkWriter writer, String symbol, boolean flushpoint, boolean replaceDotWithSlash) {
+        if (symbol == null) {
+            return 0L;
         }
-    }
+        int utf8Length = UninterruptibleUtils.String.utf8Length(symbol, false, replaceDotWithSlash ? dotWithSlash : null);
+        if (utf8Length == 0) {
+            assert writer.isLockedByCurrentThread();
+            return SubstrateJVM.getSymbolRepository().getSymbolId(EMPTY_NAME, !flushpoint);
+        }
 
-    @Uninterruptible(reason = "Needed for JfrSymbolRepository.getSymbolId().")
-    private static long getSymbolId(JfrChunkWriter writer, String symbol, boolean flushpoint, boolean replaceDotWithSlash) {
-        /*
-         * The result is only valid for the current epoch, but the epoch can't change while the
-         * current thread holds the JfrChunkWriter lock.
-         */
+        Pointer buffer = NullableNativeMemory.malloc(utf8Length, NmtCategory.JFR);
+        if (buffer.isNull()) {
+            return 0L;
+        }
+        UninterruptibleUtils.String.toUTF8(symbol, symbol.length(), buffer, buffer.add(utf8Length), false, replaceDotWithSlash ? dotWithSlash : null);
         assert writer.isLockedByCurrentThread();
-        return SubstrateJVM.getSymbolRepository().getSymbolId(symbol, !flushpoint, replaceDotWithSlash);
+        return SubstrateJVM.getSymbolRepository().getSymbolId(buffer, Word.unsigned(utf8Length), !flushpoint);
     }
 
-    /*
-     * Copy to a new buffer so each table has its own copy of the data. This simplifies cleanup and
-     * mitigates double frees.
-     */
-    @Uninterruptible(reason = "Needed for JfrSymbolRepository.getSymbolId().")
-    private static long getSymbolId(JfrChunkWriter writer, Pointer source, UnsignedWord length, boolean flushpoint) {
+    @Uninterruptible(reason = "Needed for OOME-safe symbol serialization.")
+    private static long storePreviousEpochSymbol(Pointer source, UnsignedWord length, boolean hasName) {
+        if (!hasName) {
+            return 0L;
+        }
+        if (length.equal(0)) {
+            return SubstrateJVM.getSymbolRepository().getSymbolId(EMPTY_NAME, true);
+        }
+
         Pointer destination = NullableNativeMemory.malloc(length, NmtCategory.JFR);
         if (destination.isNull()) {
             return 0L;
         }
         UnmanagedMemoryUtil.copy(source, destination, length);
-
-        assert writer.isLockedByCurrentThread();
-        return SubstrateJVM.getSymbolRepository().getSymbolId(destination, length, !flushpoint);
+        return SubstrateJVM.getSymbolRepository().getSymbolId(destination, length, true);
     }
 
-    private int writePackages(JfrChunkWriter writer, boolean flushpoint) {
-        int size = typeInfo.packages.getSize();
-        PackageInfoRaw[] table = (PackageInfoRaw[]) typeInfo.packages.getTable();
-        if (size == 0) {
+    @Uninterruptible(reason = "Needed to precompute the previous-epoch symbol ids.")
+    private long storePreviousEpochSymbol(String symbol, boolean replaceDotWithSlash) {
+        if (symbol == null) {
+            return 0L;
+        }
+        int utf8Length = UninterruptibleUtils.String.utf8Length(symbol, false, replaceDotWithSlash ? dotWithSlash : null);
+        if (utf8Length == 0) {
+            return SubstrateJVM.getSymbolRepository().getSymbolId(EMPTY_NAME, true);
+        }
+
+        Pointer buffer = NullableNativeMemory.malloc(utf8Length, NmtCategory.JFR);
+        if (buffer.isNull()) {
+            return 0L;
+        }
+        UninterruptibleUtils.String.toUTF8(symbol, symbol.length(), buffer, buffer.add(utf8Length), false, replaceDotWithSlash ? dotWithSlash : null);
+        return SubstrateJVM.getSymbolRepository().getSymbolId(buffer, Word.unsigned(utf8Length), true);
+    }
+
+    private int writePackages(JfrChunkWriter writer, TypeInfo typeInfo, boolean flushpoint) {
+        if (typeInfo.packages.isEmpty()) {
             return EMPTY;
         }
         writer.writeCompressedLong(JfrType.Package.getId());
-        writer.writeCompressedInt(size);
-
-        for (int i = 0; i < table.length; i++) {
-            PackageInfoRaw packageInfoRaw = table[i];
-            while (packageInfoRaw.isNonNull()) {
-                writePackage(writer, packageInfoRaw, flushpoint);
-                packageInfoRaw = packageInfoRaw.getNext();
-            }
+        writer.writeCompressedInt(typeInfo.packages.size());
+        for (Map.Entry<PackageKey, PackageInfo> pkgInfo : typeInfo.packages.entrySet()) {
+            writePackage(typeInfo, writer, pkgInfo.getKey(), pkgInfo.getValue(), flushpoint);
         }
         return NON_EMPTY;
     }
 
-    private void writePackage(JfrChunkWriter writer, PackageInfoRaw packageInfoRaw, boolean flushpoint) {
-        assert packageInfoRaw.getHash() != 0;
-        writer.writeCompressedLong(packageInfoRaw.getId());  // id
-        writer.writeCompressedLong(getSymbolId(writer, packageInfoRaw.getModifiedUTF8Name(), packageInfoRaw.getNameLength(), flushpoint));
-        writer.writeCompressedLong(getModuleId(packageInfoRaw.getModule()));
-        writer.writeBoolean(false); // exported
+    private void writePackage(TypeInfo typeInfo, JfrChunkWriter writer, PackageKey pkgKey, PackageInfo pkgInfo, boolean flushpoint) {
+        writer.writeCompressedLong(pkgInfo.id);
+        writer.writeCompressedLong(getSymbolId(writer, pkgKey.name, flushpoint, true));
+        writer.writeCompressedLong(getModuleId(typeInfo, pkgKey.module));
+        writer.writeBoolean(false);
     }
 
-    private int writeModules(JfrChunkWriter writer, boolean flushpoint) {
-        int size = typeInfo.modules.getSize();
-        ModuleInfoRaw[] table = (ModuleInfoRaw[]) typeInfo.modules.getTable();
-        if (size == 0) {
+    private int writeModules(JfrChunkWriter writer, TypeInfo typeInfo, boolean flushpoint) {
+        if (typeInfo.modules.isEmpty()) {
             return EMPTY;
         }
         writer.writeCompressedLong(JfrType.Module.getId());
-        writer.writeCompressedInt(size);
-
-        for (int i = 0; i < table.length; i++) {
-            ModuleInfoRaw entry = table[i];
-            while (entry.isNonNull()) {
-                writeModule(writer, entry, flushpoint);
-                entry = entry.getNext();
-            }
+        writer.writeCompressedInt(typeInfo.modules.size());
+        for (Map.Entry<Module, Long> modInfo : typeInfo.modules.entrySet()) {
+            writeModule(typeInfo, writer, modInfo.getKey(), modInfo.getValue(), flushpoint);
         }
         return NON_EMPTY;
     }
 
-    private void writeModule(JfrChunkWriter writer, ModuleInfoRaw moduleInfoRaw, boolean flushpoint) {
-        writer.writeCompressedLong(moduleInfoRaw.getId());
-        writer.writeCompressedLong(getSymbolId(writer, moduleInfoRaw.getName(), flushpoint, false));
-        writer.writeCompressedLong(0); // Version, e.g. "11.0.10-internal"
-        writer.writeCompressedLong(0); // Location, e.g. "jrt:/java.base"
-        writer.writeCompressedLong(getClassLoaderId(moduleInfoRaw.getClassLoader()));
+    private void writeModule(TypeInfo typeInfo, JfrChunkWriter writer, Module module, long id, boolean flushpoint) {
+        writer.writeCompressedLong(id);
+        writer.writeCompressedLong(getSymbolId(writer, module.getName(), flushpoint, false));
+        writer.writeCompressedLong(0);
+        writer.writeCompressedLong(0);
+        writer.writeCompressedLong(getClassLoaderId(typeInfo, module.getClassLoader()));
     }
 
-    private int writeClassLoaders(JfrChunkWriter writer, boolean flushpoint) {
-        if (typeInfo.classLoaders.getSize() == 0) {
+    private int writeClassLoaders(JfrChunkWriter writer, TypeInfo typeInfo, boolean flushpoint) {
+        if (typeInfo.classLoaders.isEmpty()) {
             return EMPTY;
         }
         writer.writeCompressedLong(JfrType.ClassLoader.getId());
-        writer.writeCompressedInt(typeInfo.classLoaders.getSize());
+        writer.writeCompressedInt(typeInfo.classLoaders.size());
+        for (Map.Entry<ClassLoader, Long> clInfo : typeInfo.classLoaders.entrySet()) {
+            writeClassLoader(writer, clInfo.getKey(), clInfo.getValue(), flushpoint);
+        }
+        return NON_EMPTY;
+    }
 
-        for (int i = 0; i < typeInfo.classLoaders.getTable().length; i++) {
-            ClassLoaderInfoRaw entry = (ClassLoaderInfoRaw) typeInfo.classLoaders.getTable()[i];
+    private void writeClassLoader(JfrChunkWriter writer, ClassLoader cl, long id, boolean flushpoint) {
+        writer.writeCompressedLong(id);
+        writer.writeCompressedLong(cl == null ? 0L : JfrTraceId.getTraceId(cl.getClass()));
+        writer.writeCompressedLong(getSymbolId(writer, cl == null ? BOOTSTRAP_NAME : cl.getName(), flushpoint, false));
+    }
+
+    private int writePreviousEpochSnapshot(JfrChunkWriter writer) {
+        int count = writePreviousEpochClasses(writer);
+        count += writePreviousEpochPackages(writer);
+        count += writePreviousEpochModules(writer);
+        count += writePreviousEpochClassLoaders(writer);
+        return count;
+    }
+
+    private int writePreviousEpochClasses(JfrChunkWriter writer) {
+        if (previousEpochSnapshot.classes.getSize() == 0) {
+            return EMPTY;
+        }
+
+        writer.writeCompressedLong(JfrType.Class.getId());
+        writer.writeCompressedInt(previousEpochSnapshot.classes.getSize());
+        SnapshotClassEntry[] table = previousEpochSnapshot.classes.getTable();
+        for (int i = 0; i < table.length; i++) {
+            SnapshotClassEntry entry = table[i];
             while (entry.isNonNull()) {
-                writeClassLoader(writer, entry, flushpoint);
+                writer.writeCompressedLong(entry.getClassId());
+                writer.writeCompressedLong(entry.getClassLoaderId());
+                writer.writeCompressedLong(entry.getNameSymbolId());
+                writer.writeCompressedLong(entry.getPackageId());
+                writer.writeCompressedLong(entry.getModifiers());
+                writer.writeBoolean(entry.getHidden());
                 entry = entry.getNext();
             }
         }
         return NON_EMPTY;
     }
 
-    private static void writeClassLoader(JfrChunkWriter writer, ClassLoaderInfoRaw classLoaderInfoRaw, boolean flushpoint) {
-        writer.writeCompressedLong(classLoaderInfoRaw.getId());
-        writer.writeCompressedLong(classLoaderInfoRaw.getClassTraceId());
-        writer.writeCompressedLong(getSymbolId(writer, classLoaderInfoRaw.getName(), flushpoint, false));
-    }
-
-    private boolean addClass(Class<?> clazz) {
-        ClassInfoRaw classInfoRaw = StackValue.get(ClassInfoRaw.class);
-        classInfoRaw.setId(JfrTraceId.getTraceId(clazz));
-        classInfoRaw.setHash(getHash(clazz.getName()));
-
-        // Once the traceID is set, we can do a look-up.
-        if (isClassVisited(classInfoRaw)) {
-            return false;
+    private int writePreviousEpochPackages(JfrChunkWriter writer) {
+        if (previousEpochSnapshot.packages.getSize() == 0) {
+            return EMPTY;
         }
 
-        classInfoRaw.setName(clazz.getName());
-        classInfoRaw.setInstance(clazz);
-        assert !typeInfo.classes.contains(classInfoRaw);
-        typeInfo.classes.putNew(classInfoRaw);
-        assert typeInfo.classes.contains(classInfoRaw);
-        return true;
-    }
-
-    private boolean isClassVisited(ClassInfoRaw classInfoRaw) {
-        return typeInfo.classes.contains(classInfoRaw) || flushedClasses.contains(classInfoRaw);
-    }
-
-    /** We cannot directly call getPackage() or getPackageName() since that may allocate. */
-    private boolean addPackage(Class<?> clazz) {
-        Module module = clazz.getModule();
-
-        PackageInfoRaw packageInfoRaw = StackValue.get(PackageInfoRaw.class);
-        packageInfoRaw.setName(null); // No allocation free way to get the name String.
-        packageInfoRaw.setHasModule(module != null);
-        packageInfoRaw.setModule(module);
-        setPackageNameAndLength(clazz, packageInfoRaw);
-
-        /*
-         * The empty/null package represented by "" is always traced with id 0. The id 0 is reserved
-         * and does not need to be serialized.
-         */
-        if (packageInfoRaw.getNameLength().equal(0)) {
-            NullableNativeMemory.free(packageInfoRaw.getModifiedUTF8Name());
-            return false;
-        }
-        packageInfoRaw.setHash(getHash(packageInfoRaw));
-        if (isPackageVisited(packageInfoRaw)) {
-            assert module == (flushedPackages.contains(packageInfoRaw) ? ((PackageInfoRaw) flushedPackages.get(packageInfoRaw)).getModule()
-                            : ((PackageInfoRaw) typeInfo.packages.get(packageInfoRaw)).getModule());
-            NullableNativeMemory.free(packageInfoRaw.getModifiedUTF8Name());
-            return false;
-        }
-
-        packageInfoRaw.setId(++currentPackageId);
-        if (((PackageInfoRaw) typeInfo.packages.putNew(packageInfoRaw)).isNull()) {
-            currentPackageId--;
-            NullableNativeMemory.free(packageInfoRaw.getModifiedUTF8Name());
-            return false;
-        }
-        // Do not free the buffer. A pointer to it is shallow copied into the hash map.
-        assert typeInfo.packages.contains(packageInfoRaw);
-        return true;
-    }
-
-    private boolean isPackageVisited(PackageInfoRaw packageInfoRaw) {
-        return flushedPackages.contains(packageInfoRaw) || typeInfo.packages.contains(packageInfoRaw);
-    }
-
-    private long getPackageId(PackageInfoRaw packageInfoRaw) {
-        if (packageInfoRaw.getModifiedUTF8Name().isNonNull() && packageInfoRaw.getNameLength().aboveOrEqual(1)) {
-            PackageInfoRaw entry;
-            if (flushedPackages.contains(packageInfoRaw)) {
-                entry = (PackageInfoRaw) flushedPackages.get(packageInfoRaw);
-            } else {
-                entry = (PackageInfoRaw) typeInfo.packages.get(packageInfoRaw);
+        writer.writeCompressedLong(JfrType.Package.getId());
+        writer.writeCompressedInt(previousEpochSnapshot.packages.getSize());
+        PackageEntry[] table = previousEpochSnapshot.packages.getTable();
+        for (int i = 0; i < table.length; i++) {
+            PackageEntry entry = table[i];
+            while (entry.isNonNull()) {
+                writer.writeCompressedLong(entry.getId());
+                writer.writeCompressedLong(entry.getNameSymbolId());
+                writer.writeCompressedLong(entry.getModuleId());
+                writer.writeBoolean(false);
+                entry = entry.getNext();
             }
-            return entry.isNonNull() ? entry.getId() : 0;
-        } else {
-            // Empty package has reserved ID 0
+        }
+        return NON_EMPTY;
+    }
+
+    private int writePreviousEpochModules(JfrChunkWriter writer) {
+        if (previousEpochSnapshot.modules.getSize() == 0) {
+            return EMPTY;
+        }
+
+        writer.writeCompressedLong(JfrType.Module.getId());
+        writer.writeCompressedInt(previousEpochSnapshot.modules.getSize());
+        SnapshotModuleEntry[] table = previousEpochSnapshot.modules.getTable();
+        for (int i = 0; i < table.length; i++) {
+            SnapshotModuleEntry entry = table[i];
+            while (entry.isNonNull()) {
+                writer.writeCompressedLong(entry.getId());
+                writer.writeCompressedLong(entry.getNameSymbolId());
+                writer.writeCompressedLong(0);
+                writer.writeCompressedLong(0);
+                writer.writeCompressedLong(entry.getClassLoaderId());
+                entry = entry.getNext();
+            }
+        }
+        return NON_EMPTY;
+    }
+
+    private int writePreviousEpochClassLoaders(JfrChunkWriter writer) {
+        int size = previousEpochSnapshot.classLoaders.getSize();
+        if (!previousEpochSnapshot.hasBootstrapClassLoader && size == 0) {
+            return EMPTY;
+        }
+
+        writer.writeCompressedLong(JfrType.ClassLoader.getId());
+        writer.writeCompressedInt(size + (previousEpochSnapshot.hasBootstrapClassLoader ? 1 : 0));
+        if (previousEpochSnapshot.hasBootstrapClassLoader) {
+            writer.writeCompressedLong(0L);
+            writer.writeCompressedLong(0L);
+            writer.writeCompressedLong(previousEpochSnapshot.bootstrapNameSymbolId);
+        }
+        SnapshotClassLoaderEntry[] table = previousEpochSnapshot.classLoaders.getTable();
+        for (int i = 0; i < table.length; i++) {
+            SnapshotClassLoaderEntry entry = table[i];
+            while (entry.isNonNull()) {
+                writer.writeCompressedLong(entry.getId());
+                writer.writeCompressedLong(entry.getClassTraceId());
+                writer.writeCompressedLong(entry.getNameSymbolId());
+                entry = entry.getNext();
+            }
+        }
+        return NON_EMPTY;
+    }
+
+    private boolean addClass(TypeInfo typeInfo, Class<?> clazz) {
+        if (typeInfo.classes.contains(clazz) || flushedClasses.contains(clazz)) {
+            return false;
+        }
+        return typeInfo.classes.add(clazz);
+    }
+
+    private boolean addPackage(TypeInfo typeInfo, Package pkg, Module module) {
+        PackageKey key = new PackageKey(pkg.getName(), module);
+        if (typeInfo.packages.containsKey(key) || flushedPackagesContains(typeInfo, key)) {
+            return false;
+        }
+        long id = key.name.isEmpty() ? 0 : ++currentPackageId;
+        typeInfo.packages.put(key, new PackageInfo(id));
+        return true;
+    }
+
+    private boolean flushedPackagesContains(TypeInfo typeInfo, PackageKey key) {
+        if (key.name.isEmpty()) {
+            return true;
+        }
+
+        long moduleId = getModuleId(typeInfo, key.module);
+        PackageEntry packageEntry = StackValue.get(PackageEntry.class);
+        if (!setUtf8Name(key.name, packageEntry, true)) {
+            return false;
+        }
+        packageEntry.setModuleId(moduleId);
+        packageEntry.setHash(getPackageHash(moduleId, packageEntry.getUtf8Name(), packageEntry.getNameLength()));
+        boolean result = flushedPackages.contains(packageEntry);
+        if (packageEntry.getUtf8Name().isNonNull()) {
+            NullableNativeMemory.free(packageEntry.getUtf8Name());
+        }
+        return result;
+    }
+
+    private long getPackageId(TypeInfo typeInfo, Class<?> clazz) {
+        Package pkg = clazz.getPackage();
+        if (pkg == null || pkg.getName().isEmpty()) {
             return 0;
         }
+
+        PackageKey key = new PackageKey(pkg.getName(), clazz.getModule());
+        PackageInfo info = typeInfo.packages.get(key);
+        if (info != null) {
+            return info.id;
+        }
+
+        long moduleId = getModuleId(typeInfo, key.module);
+        PackageEntry packageEntry = StackValue.get(PackageEntry.class);
+        if (!setUtf8Name(key.name, packageEntry, true)) {
+            return 0;
+        }
+        packageEntry.setModuleId(moduleId);
+        packageEntry.setHash(getPackageHash(moduleId, packageEntry.getUtf8Name(), packageEntry.getNameLength()));
+        PackageEntry existing = (PackageEntry) flushedPackages.get(packageEntry);
+        if (packageEntry.getUtf8Name().isNonNull()) {
+            NullableNativeMemory.free(packageEntry.getUtf8Name());
+        }
+        return existing.isNonNull() ? existing.getId() : 0;
     }
 
-    private boolean addModule(Module module) {
-        ModuleInfoRaw moduleInfoRaw = StackValue.get(ModuleInfoRaw.class);
-        moduleInfoRaw.setModule(module);
-        moduleInfoRaw.setName(module.getName());
-        moduleInfoRaw.setHash(getIdentityHash(module));
-        if (isModuleVisited(moduleInfoRaw)) {
+    private boolean addModule(TypeInfo typeInfo, Module module) {
+        if (typeInfo.modules.containsKey(module) || flushedModules.containsKey(module)) {
             return false;
         }
-        moduleInfoRaw.setId(++currentModuleId);
-        moduleInfoRaw.setHasClassLoader(module.getClassLoader() != null);
-        moduleInfoRaw.setClassLoader(module.getClassLoader());
-        if (((ModuleInfoRaw) typeInfo.modules.putNew(moduleInfoRaw)).isNull()) {
+        typeInfo.modules.put(module, ++currentModuleId);
+        return true;
+    }
+
+    private long getModuleId(TypeInfo typeInfo, Module module) {
+        if (module == null) {
+            return 0;
+        }
+        Long flushed = flushedModules.get(module);
+        if (flushed != null) {
+            return flushed;
+        }
+        Long current = typeInfo.modules.get(module);
+        return current != null ? current : 0;
+    }
+
+    private boolean addClassLoader(TypeInfo typeInfo, ClassLoader classLoader) {
+        if (typeInfo.classLoaders.containsKey(classLoader) || flushedClassLoaders.containsKey(classLoader)) {
+            return false;
+        }
+        typeInfo.classLoaders.put(classLoader, classLoader == null ? 0L : ++currentClassLoaderId);
+        return true;
+    }
+
+    private long getClassLoaderId(TypeInfo typeInfo, ClassLoader classLoader) {
+        if (classLoader == null) {
+            return 0;
+        }
+        Long flushed = flushedClassLoaders.get(classLoader);
+        if (flushed != null) {
+            return flushed;
+        }
+        Long current = typeInfo.classLoaders.get(classLoader);
+        return current != null ? current : 0;
+    }
+
+    private boolean addClass(PreviousEpochTypeSnapshot snapshot, Class<?> clazz) {
+        if (flushedClasses.contains(clazz)) {
+            return false;
+        }
+
+        long classId = JfrTraceId.getTraceId(clazz);
+        SnapshotClassEntry classEntry = StackValue.get(SnapshotClassEntry.class);
+        classEntry.setClassId(classId);
+        classEntry.setHash(getIdHash(classId));
+        if (snapshot.classes.contains(classEntry)) {
+            return false;
+        }
+
+        classEntry.setClassLoaderId(getClassLoaderId(snapshot, clazz.getClassLoader()));
+        classEntry.setNameSymbolId(storePreviousEpochSymbol(clazz.getName(), true));
+        classEntry.setPackageId(getPackageId(snapshot, clazz));
+        classEntry.setModifiers(clazz.getModifiers());
+        classEntry.setHidden(clazz.isHidden());
+        return snapshot.classes.putNew(classEntry).isNonNull();
+    }
+
+    private long getClassLoaderId(PreviousEpochTypeSnapshot snapshot, ClassLoader classLoader) {
+        if (classLoader == null) {
+            Long flushed = flushedClassLoaders.get(null);
+            if (flushed == null) {
+                snapshot.markBootstrapClassLoader();
+            }
+            return 0;
+        }
+
+        Long flushed = flushedClassLoaders.get(classLoader);
+        if (flushed != null) {
+            return flushed;
+        }
+
+        ObjectIdEntry objectIdEntry = StackValue.get(ObjectIdEntry.class);
+        objectIdEntry.setObjectRawValue(Word.objectToUntrackedPointer(classLoader).rawValue());
+        objectIdEntry.setHash(getObjectHash(classLoader));
+        ObjectIdEntry existing = (ObjectIdEntry) snapshot.classLoaderIds.get(objectIdEntry);
+        if (existing.isNonNull()) {
+            return existing.getId();
+        }
+
+        SnapshotClassLoaderEntry classLoaderEntry = StackValue.get(SnapshotClassLoaderEntry.class);
+        classLoaderEntry.setId(++currentClassLoaderId);
+        classLoaderEntry.setClassTraceId(JfrTraceId.getTraceId(classLoader.getClass()));
+        classLoaderEntry.setNameSymbolId(storePreviousEpochSymbol(classLoader.getName(), false));
+        classLoaderEntry.setHash(getIdHash(classLoaderEntry.getId()));
+        if (snapshot.classLoaders.putNew(classLoaderEntry).isNull()) {
+            currentClassLoaderId--;
+            return 0;
+        }
+
+        objectIdEntry.setId(classLoaderEntry.getId());
+        if (snapshot.classLoaderIds.putNew(objectIdEntry).isNull()) {
+            snapshot.classLoaders.remove(classLoaderEntry);
+            currentClassLoaderId--;
+            return 0;
+        }
+        return classLoaderEntry.getId();
+    }
+
+    private long getModuleId(PreviousEpochTypeSnapshot snapshot, Module module) {
+        if (module == null) {
+            return 0;
+        }
+
+        Long flushed = flushedModules.get(module);
+        if (flushed != null) {
+            return flushed;
+        }
+
+        ObjectIdEntry objectIdEntry = StackValue.get(ObjectIdEntry.class);
+        objectIdEntry.setObjectRawValue(Word.objectToUntrackedPointer(module).rawValue());
+        objectIdEntry.setHash(getObjectHash(module));
+        ObjectIdEntry existing = (ObjectIdEntry) snapshot.moduleIds.get(objectIdEntry);
+        if (existing.isNonNull()) {
+            return existing.getId();
+        }
+
+        SnapshotModuleEntry moduleEntry = StackValue.get(SnapshotModuleEntry.class);
+        moduleEntry.setId(++currentModuleId);
+        moduleEntry.setClassLoaderId(getClassLoaderId(snapshot, module.getClassLoader()));
+        moduleEntry.setNameSymbolId(storePreviousEpochSymbol(module.getName(), false));
+        moduleEntry.setHash(getIdHash(moduleEntry.getId()));
+        if (snapshot.modules.putNew(moduleEntry).isNull()) {
             currentModuleId--;
-            return false;
-        }
-        return true;
-    }
-
-    private boolean isModuleVisited(ModuleInfoRaw moduleInfoRaw) {
-        return typeInfo.modules.contains(moduleInfoRaw) || flushedModules.contains(moduleInfoRaw);
-    }
-
-    private long getModuleId(Module module) {
-        if (module != null) {
-            ModuleInfoRaw moduleInfoRaw = StackValue.get(ModuleInfoRaw.class);
-            moduleInfoRaw.setModule(module);
-            moduleInfoRaw.setHash(getIdentityHash(module));
-            ModuleInfoRaw entry;
-            if (flushedModules.contains(moduleInfoRaw)) {
-                entry = (ModuleInfoRaw) flushedModules.get(moduleInfoRaw);
-            } else {
-                entry = (ModuleInfoRaw) typeInfo.modules.get(moduleInfoRaw);
-            }
-            return entry.isNonNull() ? entry.getId() : 0;
-        } else {
             return 0;
         }
-    }
 
-    private boolean addClassLoader(ClassLoader classLoader) {
-        ClassLoaderInfoRaw classLoaderInfoRaw = StackValue.get(ClassLoaderInfoRaw.class);
-        classLoaderInfoRaw.setClassLoader(classLoader);
-        if (classLoader == null) {
-            classLoaderInfoRaw.setName(BOOTSTRAP_NAME);
-        } else {
-            classLoaderInfoRaw.setName(classLoader.getName());
-        }
-
-        classLoaderInfoRaw.setHash(getIdentityHash(classLoader));
-        if (isClassLoaderVisited(classLoaderInfoRaw)) {
-            return false;
-        }
-
-        if (classLoader == null) {
-            // Bootstrap loader has reserved ID of 0
-            classLoaderInfoRaw.setId(0);
-            classLoaderInfoRaw.setClassTraceId(0);
-        } else {
-            classLoaderInfoRaw.setId(++currentClassLoaderId);
-            classLoaderInfoRaw.setClassTraceId(JfrTraceId.getTraceId(classLoader.getClass()));
-        }
-
-        if (((ClassLoaderInfoRaw) typeInfo.classLoaders.putNew(classLoaderInfoRaw)).isNull()) {
-            if (classLoader != null) {
-                currentClassLoaderId--;
-            }
-            return false;
-        }
-        return true;
-    }
-
-    private boolean isClassLoaderVisited(ClassLoaderInfoRaw classLoaderInfoRaw) {
-        return flushedClassLoaders.contains(classLoaderInfoRaw) || typeInfo.classLoaders.contains(classLoaderInfoRaw);
-    }
-
-    private long getClassLoaderId(ClassLoader classLoader) {
-        if (classLoader == null) {
+        objectIdEntry.setId(moduleEntry.getId());
+        if (snapshot.moduleIds.putNew(objectIdEntry).isNull()) {
+            snapshot.modules.remove(moduleEntry);
+            currentModuleId--;
             return 0;
         }
-        ClassLoaderInfoRaw classLoaderInfoRaw = StackValue.get(ClassLoaderInfoRaw.class);
-        classLoaderInfoRaw.setClassLoader(classLoader);
-        classLoaderInfoRaw.setHash(getIdentityHash(classLoader));
-        ClassLoaderInfoRaw entry;
-        if (flushedClassLoaders.contains(classLoaderInfoRaw)) {
-            entry = (ClassLoaderInfoRaw) flushedClassLoaders.get(classLoaderInfoRaw);
-        } else {
-            entry = (ClassLoaderInfoRaw) typeInfo.classLoaders.get(classLoaderInfoRaw);
+        return moduleEntry.getId();
+    }
+
+    /** We cannot call getPackage() or getPackageName() when building the OOME snapshot. */
+    private long getPackageId(PreviousEpochTypeSnapshot snapshot, Class<?> clazz) {
+        PackageEntry packageEntry = StackValue.get(PackageEntry.class);
+        packageEntry.setModuleId(getModuleId(snapshot, clazz.getModule()));
+        setPackageNameAndLength(clazz, packageEntry);
+        if (packageEntry.getNameLength().equal(0)) {
+            if (packageEntry.getUtf8Name().isNonNull()) {
+                NullableNativeMemory.free(packageEntry.getUtf8Name());
+            }
+            return 0;
         }
-        return entry.isNonNull() ? entry.getId() : 0;
+
+        packageEntry.setId(0);
+        packageEntry.setNameSymbolId(0L);
+        packageEntry.setHash(getPackageHash(packageEntry.getModuleId(), packageEntry.getUtf8Name(), packageEntry.getNameLength()));
+
+        PackageEntry flushed = (PackageEntry) flushedPackages.get(packageEntry);
+        if (flushed.isNonNull()) {
+            NullableNativeMemory.free(packageEntry.getUtf8Name());
+            return flushed.getId();
+        }
+
+        PackageEntry existing = (PackageEntry) snapshot.packages.get(packageEntry);
+        if (existing.isNonNull()) {
+            NullableNativeMemory.free(packageEntry.getUtf8Name());
+            return existing.getId();
+        }
+
+        packageEntry.setId(++currentPackageId);
+        packageEntry.setNameSymbolId(storePreviousEpochSymbol(packageEntry.getUtf8Name(), packageEntry.getNameLength(), packageEntry.getHasName()));
+        if (snapshot.packages.putNew(packageEntry).isNull()) {
+            NullableNativeMemory.free(packageEntry.getUtf8Name());
+            currentPackageId--;
+            return 0;
+        }
+        return packageEntry.getId();
     }
 
     private void clearEpochData() {
         flushedClasses.clear();
-        flushedPackages.clear();
         flushedModules.clear();
         flushedClassLoaders.clear();
+        flushedPackages.clear();
+        previousEpochSnapshot.reset();
         currentPackageId = 0;
         currentModuleId = 0;
         currentClassLoaderId = 0;
         getEpochData(true).clear();
     }
 
-    private final class TypeInfo {
-        final JfrClassInfoTable classes = new JfrClassInfoTable();
-        final JfrPackageInfoTable packages = new JfrPackageInfoTable();
-        final JfrModuleInfoTable modules = new JfrModuleInfoTable();
-        final JfrClassLoaderInfoTable classLoaders = new JfrClassLoaderInfoTable();
-
-        void reset() {
-            classes.clear();
-            packages.clear();
-            modules.clear();
-            classLoaders.clear();
-        }
-
-        void teardown() {
-            classes.teardown();
-            packages.teardown();
-            modules.teardown();
-            classLoaders.teardown();
-        }
-    }
-
     /**
-     * This method sets the package name and length. packageInfoRaw may be on the stack or native
-     * memory.
+     * This method sets the package name and length. The target may be stack or heap allocated.
      */
-    private void setPackageNameAndLength(Class<?> clazz, PackageInfoRaw packageInfoRaw) {
+    private void setPackageNameAndLength(Class<?> clazz, PackageEntry target) {
         DynamicHub hub = DynamicHub.fromClass(clazz);
         if (!LayoutEncoding.isHybrid(hub.getLayoutEncoding())) {
             while (hub.hubIsArray()) {
@@ -579,87 +728,313 @@ public class JfrTypeRepository implements JfrRepository {
             }
         }
 
-        /*
-         * Primitives have the null package, which technically has the name "java.lang", but JFR
-         * still assigns these the reserved 0 id.
-         */
         if (hub.isPrimitive()) {
-            packageInfoRaw.setModifiedUTF8Name(Word.nullPointer());
-            packageInfoRaw.setNameLength(Word.unsigned(0));
+            target.setHasName(false);
+            target.setUtf8Name(Word.nullPointer());
+            target.setNameLength(Word.unsigned(0));
             return;
         }
 
-        String str = hub.getName();
-        int dot = str.lastIndexOf('.');
+        String name = hub.getName();
+        int dot = name.lastIndexOf('.');
         if (dot == -1) {
             dot = 0;
         }
 
-        int utf8Length = UninterruptibleUtils.String.utf8Length(str, false, dotWithSlash);
-        Pointer buffer = NullableNativeMemory.malloc(utf8Length, NmtCategory.JFR);
-        Pointer bufferEnd = buffer.add(utf8Length);
-
-        // If malloc fails, set a blank package name.
-        if (buffer.isNull()) {
-            packageInfoRaw.setModifiedUTF8Name(Word.nullPointer());
-            packageInfoRaw.setNameLength(Word.unsigned(0));
+        int utf8Length = UninterruptibleUtils.String.utf8Length(name, false, dotWithSlash);
+        if (utf8Length == 0) {
+            target.setHasName(true);
+            target.setUtf8Name(Word.nullPointer());
+            target.setNameLength(Word.unsigned(0));
             return;
         }
 
-        assert buffer.add(dot).belowOrEqual(bufferEnd);
-
-        /*
-         * Since we're serializing now, we must do replacements here, instead of the symbol
-         * repository.
-         */
-        Pointer packageNameEnd = UninterruptibleUtils.String.toUTF8(str, dot, buffer, bufferEnd, false, dotWithSlash);
-        packageInfoRaw.setModifiedUTF8Name(buffer);
-
-        UnsignedWord packageNameLength = packageNameEnd.subtract(buffer); // end - start
-        packageInfoRaw.setNameLength(packageNameLength);
-        if (dot == 0) {
-            assert packageNameLength.equal(0);
+        Pointer buffer = NullableNativeMemory.malloc(utf8Length, NmtCategory.JFR);
+        if (buffer.isNull()) {
+            target.setHasName(false);
+            target.setUtf8Name(Word.nullPointer());
+            target.setNameLength(Word.unsigned(0));
+            return;
         }
+
+        Pointer end = UninterruptibleUtils.String.toUTF8(name, dot, buffer, buffer.add(utf8Length), false, dotWithSlash);
+        target.setHasName(true);
+        target.setUtf8Name(buffer);
+        target.setNameLength(end.subtract(buffer));
+    }
+
+    private boolean setUtf8Name(String string, NullableNameEntry target, boolean replaceDotWithSlash) {
+        if (string == null) {
+            target.setHasName(false);
+            target.setUtf8Name(Word.nullPointer());
+            target.setNameLength(Word.unsigned(0));
+            return true;
+        }
+
+        int utf8Length = UninterruptibleUtils.String.utf8Length(string, false, replaceDotWithSlash ? dotWithSlash : null);
+        target.setHasName(true);
+        target.setNameLength(Word.unsigned(utf8Length));
+        if (utf8Length == 0) {
+            target.setUtf8Name(Word.nullPointer());
+            return true;
+        }
+
+        Pointer buffer = NullableNativeMemory.malloc(utf8Length, NmtCategory.JFR);
+        if (buffer.isNull()) {
+            target.setHasName(false);
+            target.setUtf8Name(Word.nullPointer());
+            target.setNameLength(Word.unsigned(0));
+            return false;
+        }
+        UninterruptibleUtils.String.toUTF8(string, string.length(), buffer, buffer.add(utf8Length), false, replaceDotWithSlash ? dotWithSlash : null);
+        target.setUtf8Name(buffer);
+        return true;
     }
 
     @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
-    private static int getHash(String imageHeapString) {
-        // It's possible the type exists, but has no name.
-        if (imageHeapString == null) {
-            return 0;
-        }
-        long rawPointerValue = Word.objectToUntrackedPointer(imageHeapString).rawValue();
-        return UninterruptibleUtils.Long.hashCode(rawPointerValue);
+    private static int getIdHash(long value) {
+        return UninterruptibleUtils.Long.hashCode(value);
     }
 
-    /**
-     * We do not have access to an image heap String for packages. Instead, sum the value of the
-     * serialized String and use that for the hash.
-     */
-    private static int getHash(PackageInfoRaw packageInfoRaw) {
-        if (packageInfoRaw.getModifiedUTF8Name().isNull() || packageInfoRaw.getNameLength().belowOrEqual(0)) {
-            return 0;
-        }
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    private static int getObjectHash(Object object) {
+        return object == null ? 0 : UninterruptibleUtils.Long.hashCode(Word.objectToUntrackedPointer(object).rawValue());
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    private static int getPackageHash(long moduleId, Pointer buffer, UnsignedWord length) {
         long sum = 0;
-        for (int i = 0; packageInfoRaw.getNameLength().aboveThan(i); i++) {
-            sum += (packageInfoRaw.getModifiedUTF8Name()).readByte(i);
+        for (int i = 0; length.aboveThan(i); i++) {
+            sum += buffer.readByte(i);
         }
-        return 31 * UninterruptibleUtils.Long.hashCode(sum) + getIdentityHash(packageInfoRaw.getModule());
+        return 31 * UninterruptibleUtils.Long.hashCode(sum) + getIdHash(moduleId);
     }
 
-    private static int getIdentityHash(Object object) {
-        return object != null ? System.identityHashCode(object) : 0;
+    private static final class PackageKey {
+        private final String name;
+        private final Module module;
+
+        PackageKey(String name, Module module) {
+            this.name = name;
+            this.module = module;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof PackageKey other)) {
+                return false;
+            }
+            return module == other.module && name.equals(other.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * name.hashCode() + System.identityHashCode(module);
+        }
+    }
+
+    private static final class PackageInfo {
+        private final long id;
+
+        PackageInfo(long id) {
+            this.id = id;
+        }
+    }
+
+    private static final class TypeInfo {
+        final EconomicSet<Class<?>> classes = EconomicSet.create();
+        final Map<PackageKey, PackageInfo> packages = new HashMap<>();
+        final Map<Module, Long> modules = new IdentityHashMap<>();
+        final Map<ClassLoader, Long> classLoaders = new IdentityHashMap<>();
+    }
+
+    private final class PreviousEpochTypeSnapshot {
+        final SnapshotClassTable classes = new SnapshotClassTable();
+        final JfrPackageTable packages = new JfrPackageTable();
+        final SnapshotModuleTable modules = new SnapshotModuleTable();
+        final SnapshotClassLoaderTable classLoaders = new SnapshotClassLoaderTable();
+        final ObjectIdTable moduleIds = new ObjectIdTable();
+        final ObjectIdTable classLoaderIds = new ObjectIdTable();
+        boolean hasBootstrapClassLoader;
+        long bootstrapNameSymbolId;
+
+        void reset() {
+            classes.clear();
+            packages.clear();
+            modules.clear();
+            classLoaders.clear();
+            moduleIds.clear();
+            classLoaderIds.clear();
+            hasBootstrapClassLoader = false;
+            bootstrapNameSymbolId = 0L;
+        }
+
+        void teardown() {
+            classes.teardown();
+            packages.teardown();
+            modules.teardown();
+            classLoaders.teardown();
+            moduleIds.teardown();
+            classLoaderIds.teardown();
+            hasBootstrapClassLoader = false;
+            bootstrapNameSymbolId = 0L;
+        }
+
+        void markBootstrapClassLoader() {
+            hasBootstrapClassLoader = true;
+            if (bootstrapNameSymbolId == 0L) {
+                bootstrapNameSymbolId = storePreviousEpochSymbol(BOOTSTRAP_NAME, false);
+            }
+        }
     }
 
     @RawStructure
-    private interface JfrTypeInfo extends UninterruptibleEntry {
-        @PinnedObjectField
+    private interface ClassInfoRaw extends UninterruptibleEntry {
         @RawField
-        void setName(String value);
+        void setId(long value);
+
+        @RawField
+        long getId();
 
         @PinnedObjectField
         @RawField
-        String getName();
+        void setClazz(Class<?> value);
+
+        @PinnedObjectField
+        @RawField
+        Class<?> getClazz();
+    }
+
+    @RawStructure
+    private interface SnapshotClassEntry extends UninterruptibleEntry {
+        @RawField
+        void setClassId(long value);
+
+        @RawField
+        long getClassId();
+
+        @RawField
+        void setClassLoaderId(long value);
+
+        @RawField
+        long getClassLoaderId();
+
+        @RawField
+        void setNameSymbolId(long value);
+
+        @RawField
+        long getNameSymbolId();
+
+        @RawField
+        void setPackageId(long value);
+
+        @RawField
+        long getPackageId();
+
+        @RawField
+        void setModifiers(int value);
+
+        @RawField
+        int getModifiers();
+
+        @RawField
+        void setHidden(boolean value);
+
+        @RawField
+        boolean getHidden();
+    }
+
+    @RawStructure
+    private interface NullableNameEntry extends UninterruptibleEntry {
+        @RawField
+        void setHasName(boolean value);
+
+        @RawField
+        boolean getHasName();
+
+        @RawField
+        void setUtf8Name(Pointer value);
+
+        @RawField
+        Pointer getUtf8Name();
+
+        @RawField
+        void setNameLength(UnsignedWord value);
+
+        @RawField
+        UnsignedWord getNameLength();
+    }
+
+    @RawStructure
+    private interface PackageEntry extends NullableNameEntry {
+        @RawField
+        void setId(long value);
+
+        @RawField
+        long getId();
+
+        @RawField
+        void setModuleId(long value);
+
+        @RawField
+        long getModuleId();
+
+        @RawField
+        void setNameSymbolId(long value);
+
+        @RawField
+        long getNameSymbolId();
+    }
+
+    @RawStructure
+    private interface SnapshotModuleEntry extends UninterruptibleEntry {
+        @RawField
+        void setId(long value);
+
+        @RawField
+        long getId();
+
+        @RawField
+        void setClassLoaderId(long value);
+
+        @RawField
+        long getClassLoaderId();
+
+        @RawField
+        void setNameSymbolId(long value);
+
+        @RawField
+        long getNameSymbolId();
+    }
+
+    @RawStructure
+    private interface SnapshotClassLoaderEntry extends UninterruptibleEntry {
+        @RawField
+        void setId(long value);
+
+        @RawField
+        long getId();
+
+        @RawField
+        void setClassTraceId(long value);
+
+        @RawField
+        long getClassTraceId();
+
+        @RawField
+        void setNameSymbolId(long value);
+
+        @RawField
+        long getNameSymbolId();
+    }
+
+    @RawStructure
+    private interface ObjectIdEntry extends UninterruptibleEntry {
+        @RawField
+        void setObjectRawValue(long value);
+
+        @RawField
+        long getObjectRawValue();
 
         @RawField
         void setId(long value);
@@ -668,115 +1043,25 @@ public class JfrTypeRepository implements JfrRepository {
         long getId();
     }
 
-    @RawStructure
-    private interface ClassInfoRaw extends JfrTypeInfo {
-        @PinnedObjectField
-        @RawField
-        void setInstance(Class<?> value);
-
-        @PinnedObjectField
-        @RawField
-        Class<?> getInstance();
-    }
-
-    @RawStructure
-    private interface PackageInfoRaw extends JfrTypeInfo {
-        @PinnedObjectField
-        @RawField
-        void setModule(Module value);
-
-        @PinnedObjectField
-        @RawField
-        Module getModule();
-
-        @RawField
-        void setHasModule(boolean value);
-
-        @RawField
-        boolean getHasModule();
-
-        @RawField
-        void setNameLength(UnsignedWord value);
-
-        @RawField
-        UnsignedWord getNameLength();
-
-        @RawField
-        void setModifiedUTF8Name(Pointer value);
-
-        @RawField
-        Pointer getModifiedUTF8Name();
-    }
-
-    @RawStructure
-    private interface ModuleInfoRaw extends JfrTypeInfo {
-        @PinnedObjectField
-        @RawField
-        void setModule(Module value);
-
-        @PinnedObjectField
-        @RawField
-        Module getModule();
-
-        @PinnedObjectField
-        @RawField
-        void setClassLoader(ClassLoader value);
-
-        @PinnedObjectField
-        @RawField
-        ClassLoader getClassLoader();
-
-        // Needed because CL name may be empty or null, even if CL is non-null
-        @RawField
-        void setHasClassLoader(boolean value);
-
-        @RawField
-        boolean getHasClassLoader();
-    }
-
-    @RawStructure
-    private interface ClassLoaderInfoRaw extends JfrTypeInfo {
-        @PinnedObjectField
-        @RawField
-        void setClassLoader(ClassLoader value);
-
-        @PinnedObjectField
-        @RawField
-        ClassLoader getClassLoader();
-
-        @RawField
-        void setClassTraceId(long value);
-
-        @RawField
-        long getClassTraceId();
-    }
-
-    private abstract class JfrTypeInfoTable extends AbstractUninterruptibleHashtable {
-        JfrTypeInfoTable(NmtCategory nmtCategory) {
-            super(nmtCategory);
+    private static abstract class NullableNameTable extends AbstractUninterruptibleHashtable {
+        @Platforms(Platform.HOSTED_ONLY.class)
+        NullableNameTable() {
+            super(NmtCategory.JFR);
         }
 
         @Override
-        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-        protected boolean isEqual(UninterruptibleEntry v0, UninterruptibleEntry v1) {
-            JfrTypeInfo a = (JfrTypeInfo) v0;
-            JfrTypeInfo b = (JfrTypeInfo) v1;
-            return a.getName() != null ? a.getName().equals(b.getName()) : b.getName() == null;
-        }
-
-        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-        public void putAll(JfrTypeInfoTable sourceTable) {
-            for (int i = 0; i < sourceTable.getTable().length; i++) {
-                JfrTypeInfo entry = (JfrTypeInfo) sourceTable.getTable()[i];
-                while (entry.isNonNull()) {
-                    putNew(entry);
-                    entry = entry.getNext();
-                }
+        @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+        protected void free(UninterruptibleEntry entry) {
+            NullableNameEntry nameEntry = (NullableNameEntry) entry;
+            if (nameEntry.getUtf8Name().isNonNull()) {
+                NullableNativeMemory.free(nameEntry.getUtf8Name());
+                nameEntry.setUtf8Name(Word.nullPointer());
             }
+            super.free(entry);
         }
     }
 
-    private final class JfrClassInfoTable extends JfrTypeInfoTable {
+    private static final class JfrClassInfoTable extends AbstractUninterruptibleHashtable {
         @Platforms(Platform.HOSTED_ONLY.class)
         JfrClassInfoTable() {
             super(NmtCategory.JFR);
@@ -791,139 +1076,182 @@ public class JfrTypeRepository implements JfrRepository {
         @Override
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
         protected boolean isEqual(UninterruptibleEntry v0, UninterruptibleEntry v1) {
-            JfrTypeInfo a = (JfrTypeInfo) v0;
-            JfrTypeInfo b = (JfrTypeInfo) v1;
-            return a.getId() == b.getId();
+            return ((ClassInfoRaw) v0).getId() == ((ClassInfoRaw) v1).getId();
         }
 
         @Override
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-        protected UninterruptibleEntry copyToHeap(UninterruptibleEntry visitedOnStack) {
-            return copyToHeap(visitedOnStack, SizeOf.unsigned(ClassInfoRaw.class));
+        protected UninterruptibleEntry copyToHeap(UninterruptibleEntry valueOnStack) {
+            return copyToHeap(valueOnStack, SizeOf.unsigned(ClassInfoRaw.class));
         }
     }
 
-    private final class JfrPackageInfoTable extends JfrTypeInfoTable {
+    private static final class SnapshotClassTable extends AbstractUninterruptibleHashtable {
         @Platforms(Platform.HOSTED_ONLY.class)
-        JfrPackageInfoTable() {
+        SnapshotClassTable() {
             super(NmtCategory.JFR);
         }
 
         @Override
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-        protected PackageInfoRaw[] createTable(int size) {
-            return new PackageInfoRaw[size];
-        }
-
-        @Override
-        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-        protected UninterruptibleEntry copyToHeap(UninterruptibleEntry visitedOnStack) {
-            return copyToHeap(visitedOnStack, SizeOf.unsigned(PackageInfoRaw.class));
+        protected SnapshotClassEntry[] createTable(int size) {
+            return new SnapshotClassEntry[size];
         }
 
         @Override
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
         protected boolean isEqual(UninterruptibleEntry v0, UninterruptibleEntry v1) {
-            // IDs cannot be compared since they are only assigned after checking the table.
-            PackageInfoRaw entry1 = (PackageInfoRaw) v0;
-            PackageInfoRaw entry2 = (PackageInfoRaw) v1;
-            return entry1.getModule() == entry2.getModule() &&
-                            entry1.getNameLength().equal(entry2.getNameLength()) &&
-                            LibC.memcmp(entry1.getModifiedUTF8Name(), entry2.getModifiedUTF8Name(), entry1.getNameLength()) == 0;
+            return ((SnapshotClassEntry) v0).getClassId() == ((SnapshotClassEntry) v1).getClassId();
         }
 
         @Override
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-        protected void free(UninterruptibleEntry entry) {
-            PackageInfoRaw packageInfoRaw = (PackageInfoRaw) entry;
-            /* The base method will free only the entry itself, not the utf8 data. */
-            NullableNativeMemory.free(packageInfoRaw.getModifiedUTF8Name());
-            packageInfoRaw.setModifiedUTF8Name(Word.nullPointer());
-            super.free(entry);
+        protected UninterruptibleEntry copyToHeap(UninterruptibleEntry valueOnStack) {
+            return copyToHeap(valueOnStack, SizeOf.unsigned(SnapshotClassEntry.class));
         }
 
+        @Override
+        @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+        public SnapshotClassEntry[] getTable() {
+            return (SnapshotClassEntry[]) super.getTable();
+        }
+    }
+
+    private static final class JfrPackageTable extends NullableNameTable {
+        @Platforms(Platform.HOSTED_ONLY.class)
+        JfrPackageTable() {
+            super();
+        }
+
+        @Override
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-        public void putAll(JfrPackageInfoTable sourceTable) {
-            for (int i = 0; i < sourceTable.getTable().length; i++) {
-                PackageInfoRaw sourceInfo = (PackageInfoRaw) sourceTable.getTable()[i];
-                while (sourceInfo.isNonNull()) {
-                    if (!contains(sourceInfo)) {
-                        // Put if not already there.
-                        PackageInfoRaw destinationInfo = (PackageInfoRaw) putNew(sourceInfo);
-                        if (destinationInfo.isNull()) {
-                            sourceInfo = sourceInfo.getNext();
-                            continue;
-                        }
-                        destinationInfo.setModifiedUTF8Name(Word.nullPointer());
-                        // allocate a new buffer.
-                        Pointer newUtf8Name = NullableNativeMemory.malloc(sourceInfo.getNameLength(), NmtCategory.JFR);
-                        if (newUtf8Name.isNull()) {
-                            remove(destinationInfo);
-                            sourceInfo = sourceInfo.getNext();
-                            continue;
-                        }
-                        // set the buffer ptr.
-                        destinationInfo.setModifiedUTF8Name(newUtf8Name);
-                        // Copy source buffer contents over to new buffer.
-                        UnmanagedMemoryUtil.copy(sourceInfo.getModifiedUTF8Name(), newUtf8Name, sourceInfo.getNameLength());
-                    }
-                    sourceInfo = sourceInfo.getNext();
+        protected PackageEntry[] createTable(int size) {
+            return new PackageEntry[size];
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        protected boolean isEqual(UninterruptibleEntry v0, UninterruptibleEntry v1) {
+            PackageEntry a = (PackageEntry) v0;
+            PackageEntry b = (PackageEntry) v1;
+            return a.getModuleId() == b.getModuleId() &&
+                            a.getNameLength().equal(b.getNameLength()) &&
+                            LibC.memcmp(a.getUtf8Name(), b.getUtf8Name(), a.getNameLength()) == 0;
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        protected UninterruptibleEntry copyToHeap(UninterruptibleEntry valueOnStack) {
+            return copyToHeap(valueOnStack, SizeOf.unsigned(PackageEntry.class));
+        }
+
+        @Override
+        @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+        public PackageEntry[] getTable() {
+            return (PackageEntry[]) super.getTable();
+        }
+
+        void putAll(TypeInfo typeInfo, JfrTypeRepository repository) {
+            for (Map.Entry<PackageKey, PackageInfo> entry : typeInfo.packages.entrySet()) {
+                PackageEntry packageEntry = StackValue.get(PackageEntry.class);
+                if (!repository.setUtf8Name(entry.getKey().name, packageEntry, true)) {
+                    continue;
+                }
+                packageEntry.setModuleId(repository.getModuleId(typeInfo, entry.getKey().module));
+                packageEntry.setId(entry.getValue().id);
+                packageEntry.setNameSymbolId(0L);
+                packageEntry.setHash(getPackageHash(packageEntry.getModuleId(), packageEntry.getUtf8Name(), packageEntry.getNameLength()));
+                if (packageEntry.getId() != 0 && !contains(packageEntry) && putNew(packageEntry).isNull() && packageEntry.getUtf8Name().isNonNull()) {
+                    NullableNativeMemory.free(packageEntry.getUtf8Name());
                 }
             }
         }
     }
 
-    private final class JfrModuleInfoTable extends JfrTypeInfoTable {
+    private static final class SnapshotModuleTable extends AbstractUninterruptibleHashtable {
         @Platforms(Platform.HOSTED_ONLY.class)
-        JfrModuleInfoTable() {
+        SnapshotModuleTable() {
             super(NmtCategory.JFR);
         }
 
         @Override
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-        protected ModuleInfoRaw[] createTable(int size) {
-            return new ModuleInfoRaw[size];
-        }
-
-        @Override
-        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-        protected UninterruptibleEntry copyToHeap(UninterruptibleEntry visitedOnStack) {
-            return copyToHeap(visitedOnStack, SizeOf.unsigned(ModuleInfoRaw.class));
+        protected SnapshotModuleEntry[] createTable(int size) {
+            return new SnapshotModuleEntry[size];
         }
 
         @Override
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
         protected boolean isEqual(UninterruptibleEntry v0, UninterruptibleEntry v1) {
-            ModuleInfoRaw a = (ModuleInfoRaw) v0;
-            ModuleInfoRaw b = (ModuleInfoRaw) v1;
-            return a.getModule() == b.getModule();
+            return ((SnapshotModuleEntry) v0).getId() == ((SnapshotModuleEntry) v1).getId();
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        protected UninterruptibleEntry copyToHeap(UninterruptibleEntry valueOnStack) {
+            return copyToHeap(valueOnStack, SizeOf.unsigned(SnapshotModuleEntry.class));
+        }
+
+        @Override
+        @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+        public SnapshotModuleEntry[] getTable() {
+            return (SnapshotModuleEntry[]) super.getTable();
         }
     }
 
-    private final class JfrClassLoaderInfoTable extends JfrTypeInfoTable {
+    private static final class SnapshotClassLoaderTable extends AbstractUninterruptibleHashtable {
         @Platforms(Platform.HOSTED_ONLY.class)
-        JfrClassLoaderInfoTable() {
+        SnapshotClassLoaderTable() {
             super(NmtCategory.JFR);
         }
 
         @Override
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-        protected ClassLoaderInfoRaw[] createTable(int size) {
-            return new ClassLoaderInfoRaw[size];
-        }
-
-        @Override
-        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-        protected UninterruptibleEntry copyToHeap(UninterruptibleEntry visitedOnStack) {
-            return copyToHeap(visitedOnStack, SizeOf.unsigned(ClassLoaderInfoRaw.class));
+        protected SnapshotClassLoaderEntry[] createTable(int size) {
+            return new SnapshotClassLoaderEntry[size];
         }
 
         @Override
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
         protected boolean isEqual(UninterruptibleEntry v0, UninterruptibleEntry v1) {
-            ClassLoaderInfoRaw a = (ClassLoaderInfoRaw) v0;
-            ClassLoaderInfoRaw b = (ClassLoaderInfoRaw) v1;
-            return a.getClassLoader() == b.getClassLoader();
+            return ((SnapshotClassLoaderEntry) v0).getId() == ((SnapshotClassLoaderEntry) v1).getId();
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        protected UninterruptibleEntry copyToHeap(UninterruptibleEntry valueOnStack) {
+            return copyToHeap(valueOnStack, SizeOf.unsigned(SnapshotClassLoaderEntry.class));
+        }
+
+        @Override
+        @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+        public SnapshotClassLoaderEntry[] getTable() {
+            return (SnapshotClassLoaderEntry[]) super.getTable();
+        }
+    }
+
+    private static final class ObjectIdTable extends AbstractUninterruptibleHashtable {
+        @Platforms(Platform.HOSTED_ONLY.class)
+        ObjectIdTable() {
+            super(NmtCategory.JFR);
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        protected ObjectIdEntry[] createTable(int size) {
+            return new ObjectIdEntry[size];
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        protected boolean isEqual(UninterruptibleEntry v0, UninterruptibleEntry v1) {
+            return ((ObjectIdEntry) v0).getObjectRawValue() == ((ObjectIdEntry) v1).getObjectRawValue();
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        protected UninterruptibleEntry copyToHeap(UninterruptibleEntry valueOnStack) {
+            return copyToHeap(valueOnStack, SizeOf.unsigned(ObjectIdEntry.class));
         }
     }
 
@@ -931,10 +1259,7 @@ public class JfrTypeRepository implements JfrRepository {
         @Override
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
         public char replace(char ch) {
-            if (ch == '.') {
-                return '/';
-            }
-            return ch;
+            return ch == '.' ? '/' : ch;
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
@@ -48,6 +48,7 @@ import com.oracle.svm.core.hub.LayoutEncoding;
 import com.oracle.svm.guest.staging.Uninterruptible;
 import com.oracle.svm.core.jfr.traceid.JfrTraceId;
 import com.oracle.svm.core.jfr.traceid.JfrTraceIdEpoch;
+import com.oracle.svm.core.locks.VMMutex;
 import com.oracle.svm.core.nmt.NmtCategory;
 import com.oracle.svm.core.memory.NullableNativeMemory;
 
@@ -82,6 +83,7 @@ public class JfrTypeRepository implements JfrRepository {
      */
     private final JfrClassInfoTable epochTypeData0;
     private final JfrClassInfoTable epochTypeData1;
+    private final VMMutex classIdMutex;
 
     private final UninterruptibleUtils.CharReplacer dotWithSlash;
     private long currentPackageId = 0;
@@ -97,6 +99,7 @@ public class JfrTypeRepository implements JfrRepository {
 
         typeInfo = new TypeInfo();
         dotWithSlash = new ReplaceDotWithSlash();
+        classIdMutex = new VMMutex("jfrTypeRepositoryClassId");
 
         epochTypeData0 = new JfrClassInfoTable();
         epochTypeData1 = new JfrClassInfoTable();
@@ -122,7 +125,14 @@ public class JfrTypeRepository implements JfrRepository {
         classInfoRaw.setHash(getHash(clazz.getName()));
         classInfoRaw.setName(clazz.getName());
         classInfoRaw.setInstance(clazz);
-        classInfoTable.putIfAbsent(classInfoRaw);
+        classIdMutex.lockNoTransition();
+        try {
+            if (classInfoTable.getOrPut(classInfoRaw).isNull()) {
+                return 0L;
+            }
+        } finally {
+            classIdMutex.unlock();
+        }
 
         return JfrTraceId.load(clazz);
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
@@ -235,12 +235,13 @@ public class JfrTypeRepository implements JfrRepository {
         assert classInfoRaw.getHash() != 0;
         Class<?> clazz = classInfoRaw.getInstance();
         PackageInfoRaw packageInfoRaw = StackValue.get(PackageInfoRaw.class);
+        packageInfoRaw.setHasModule(clazz.getModule() != null);
+        packageInfoRaw.setModule(clazz.getModule());
         setPackageNameAndLength(clazz, packageInfoRaw);
         packageInfoRaw.setHash(getHash(packageInfoRaw));
 
-        boolean hasClassLoader = clazz.getClassLoader() != null;
         writer.writeCompressedLong(classInfoRaw.getId());
-        writer.writeCompressedLong(getClassLoaderId(hasClassLoader ? clazz.getClassLoader().getName() : null, hasClassLoader));
+        writer.writeCompressedLong(getClassLoaderId(clazz.getClassLoader()));
         writer.writeCompressedLong(getSymbolId(writer, clazz.getName(), flushpoint, true));
         writer.writeCompressedLong(getPackageId(packageInfoRaw));
         writer.writeCompressedLong(clazz.getModifiers());
@@ -301,7 +302,7 @@ public class JfrTypeRepository implements JfrRepository {
         assert packageInfoRaw.getHash() != 0;
         writer.writeCompressedLong(packageInfoRaw.getId());  // id
         writer.writeCompressedLong(getSymbolId(writer, packageInfoRaw.getModifiedUTF8Name(), packageInfoRaw.getNameLength(), flushpoint));
-        writer.writeCompressedLong(getModuleId(packageInfoRaw.getModuleName(), packageInfoRaw.getHasModule()));
+        writer.writeCompressedLong(getModuleId(packageInfoRaw.getModule()));
         writer.writeBoolean(false); // exported
     }
 
@@ -329,7 +330,7 @@ public class JfrTypeRepository implements JfrRepository {
         writer.writeCompressedLong(getSymbolId(writer, moduleInfoRaw.getName(), flushpoint, false));
         writer.writeCompressedLong(0); // Version, e.g. "11.0.10-internal"
         writer.writeCompressedLong(0); // Location, e.g. "jrt:/java.base"
-        writer.writeCompressedLong(getClassLoaderId(moduleInfoRaw.getClassLoaderName(), moduleInfoRaw.getHasClassLoader()));
+        writer.writeCompressedLong(getClassLoaderId(moduleInfoRaw.getClassLoader()));
     }
 
     private int writeClassLoaders(JfrChunkWriter writer, boolean flushpoint) {
@@ -379,11 +380,12 @@ public class JfrTypeRepository implements JfrRepository {
 
     /** We cannot directly call getPackage() or getPackageName() since that may allocate. */
     private boolean addPackage(Class<?> clazz) {
-        boolean hasModule = clazz.getModule() != null;
-        String moduleName = hasModule ? clazz.getModule().getName() : null;
+        Module module = clazz.getModule();
 
         PackageInfoRaw packageInfoRaw = StackValue.get(PackageInfoRaw.class);
         packageInfoRaw.setName(null); // No allocation free way to get the name String.
+        packageInfoRaw.setHasModule(module != null);
+        packageInfoRaw.setModule(module);
         setPackageNameAndLength(clazz, packageInfoRaw);
 
         /*
@@ -396,15 +398,13 @@ public class JfrTypeRepository implements JfrRepository {
         }
         packageInfoRaw.setHash(getHash(packageInfoRaw));
         if (isPackageVisited(packageInfoRaw)) {
-            assert moduleName == (flushedPackages.contains(packageInfoRaw) ? ((PackageInfoRaw) flushedPackages.get(packageInfoRaw)).getModuleName()
-                            : ((PackageInfoRaw) typeInfo.packages.get(packageInfoRaw)).getModuleName());
+            assert module == (flushedPackages.contains(packageInfoRaw) ? ((PackageInfoRaw) flushedPackages.get(packageInfoRaw)).getModule()
+                            : ((PackageInfoRaw) typeInfo.packages.get(packageInfoRaw)).getModule());
             NullableNativeMemory.free(packageInfoRaw.getModifiedUTF8Name());
             return false;
         }
 
         packageInfoRaw.setId(++currentPackageId);
-        packageInfoRaw.setHasModule(hasModule);
-        packageInfoRaw.setModuleName(moduleName);
         typeInfo.packages.putNew(packageInfoRaw);
         // Do not free the buffer. A pointer to it is shallow copied into the hash map.
         assert typeInfo.packages.contains(packageInfoRaw);
@@ -429,14 +429,15 @@ public class JfrTypeRepository implements JfrRepository {
 
     private boolean addModule(Module module) {
         ModuleInfoRaw moduleInfoRaw = StackValue.get(ModuleInfoRaw.class);
+        moduleInfoRaw.setModule(module);
         moduleInfoRaw.setName(module.getName());
-        moduleInfoRaw.setHash(getHash(module.getName()));
+        moduleInfoRaw.setHash(getIdentityHash(module));
         if (isModuleVisited(moduleInfoRaw)) {
             return false;
         }
         moduleInfoRaw.setId(++currentModuleId);
         moduleInfoRaw.setHasClassLoader(module.getClassLoader() != null);
-        moduleInfoRaw.setClassLoaderName(moduleInfoRaw.getHasClassLoader() ? module.getClassLoader().getName() : null);
+        moduleInfoRaw.setClassLoader(module.getClassLoader());
         typeInfo.modules.putNew(moduleInfoRaw);
         return true;
     }
@@ -445,11 +446,11 @@ public class JfrTypeRepository implements JfrRepository {
         return typeInfo.modules.contains(moduleInfoRaw) || flushedModules.contains(moduleInfoRaw);
     }
 
-    private long getModuleId(String moduleName, boolean hasModule) {
-        if (hasModule) {
+    private long getModuleId(Module module) {
+        if (module != null) {
             ModuleInfoRaw moduleInfoRaw = StackValue.get(ModuleInfoRaw.class);
-            moduleInfoRaw.setName(moduleName);
-            moduleInfoRaw.setHash(getHash(moduleName));
+            moduleInfoRaw.setModule(module);
+            moduleInfoRaw.setHash(getIdentityHash(module));
             if (flushedModules.contains(moduleInfoRaw)) {
                 return ((ModuleInfoRaw) flushedModules.get(moduleInfoRaw)).getId();
             }
@@ -461,13 +462,14 @@ public class JfrTypeRepository implements JfrRepository {
 
     private boolean addClassLoader(ClassLoader classLoader) {
         ClassLoaderInfoRaw classLoaderInfoRaw = StackValue.get(ClassLoaderInfoRaw.class);
+        classLoaderInfoRaw.setClassLoader(classLoader);
         if (classLoader == null) {
             classLoaderInfoRaw.setName(BOOTSTRAP_NAME);
         } else {
             classLoaderInfoRaw.setName(classLoader.getName());
         }
 
-        classLoaderInfoRaw.setHash(getHash(classLoaderInfoRaw.getName()));
+        classLoaderInfoRaw.setHash(getIdentityHash(classLoader));
         if (isClassLoaderVisited(classLoaderInfoRaw)) {
             return false;
         }
@@ -489,18 +491,17 @@ public class JfrTypeRepository implements JfrRepository {
         return flushedClassLoaders.contains(classLoaderInfoRaw) || typeInfo.classLoaders.contains(classLoaderInfoRaw);
     }
 
-    private long getClassLoaderId(String classLoaderName, boolean hasClassLoader) {
-        if (hasClassLoader) {
-            ClassLoaderInfoRaw classLoaderInfoRaw = StackValue.get(ClassLoaderInfoRaw.class);
-            classLoaderInfoRaw.setName(classLoaderName);
-            classLoaderInfoRaw.setHash(getHash(classLoaderName));
-            if (flushedClassLoaders.contains(classLoaderInfoRaw)) {
-                return ((ClassLoaderInfoRaw) flushedClassLoaders.get(classLoaderInfoRaw)).getId();
-            }
-            return ((ClassLoaderInfoRaw) typeInfo.classLoaders.get(classLoaderInfoRaw)).getId();
+    private long getClassLoaderId(ClassLoader classLoader) {
+        if (classLoader == null) {
+            return 0;
         }
-        // Bootstrap classloader
-        return 0;
+        ClassLoaderInfoRaw classLoaderInfoRaw = StackValue.get(ClassLoaderInfoRaw.class);
+        classLoaderInfoRaw.setClassLoader(classLoader);
+        classLoaderInfoRaw.setHash(getIdentityHash(classLoader));
+        if (flushedClassLoaders.contains(classLoaderInfoRaw)) {
+            return ((ClassLoaderInfoRaw) flushedClassLoaders.get(classLoaderInfoRaw)).getId();
+        }
+        return ((ClassLoaderInfoRaw) typeInfo.classLoaders.get(classLoaderInfoRaw)).getId();
     }
 
     private void clearEpochData() {
@@ -612,7 +613,11 @@ public class JfrTypeRepository implements JfrRepository {
         for (int i = 0; packageInfoRaw.getNameLength().aboveThan(i); i++) {
             sum += (packageInfoRaw.getModifiedUTF8Name()).readByte(i);
         }
-        return UninterruptibleUtils.Long.hashCode(sum);
+        return 31 * UninterruptibleUtils.Long.hashCode(sum) + getIdentityHash(packageInfoRaw.getModule());
+    }
+
+    private static int getIdentityHash(Object object) {
+        return object != null ? System.identityHashCode(object) : 0;
     }
 
     @RawStructure
@@ -647,11 +652,11 @@ public class JfrTypeRepository implements JfrRepository {
     private interface PackageInfoRaw extends JfrTypeInfo {
         @PinnedObjectField
         @RawField
-        void setModuleName(String value);
+        void setModule(Module value);
 
         @PinnedObjectField
         @RawField
-        String getModuleName();
+        Module getModule();
 
         @RawField
         void setHasModule(boolean value);
@@ -676,11 +681,19 @@ public class JfrTypeRepository implements JfrRepository {
     private interface ModuleInfoRaw extends JfrTypeInfo {
         @PinnedObjectField
         @RawField
-        void setClassLoaderName(String value);
+        void setModule(Module value);
 
         @PinnedObjectField
         @RawField
-        String getClassLoaderName();
+        Module getModule();
+
+        @PinnedObjectField
+        @RawField
+        void setClassLoader(ClassLoader value);
+
+        @PinnedObjectField
+        @RawField
+        ClassLoader getClassLoader();
 
         // Needed because CL name may be empty or null, even if CL is non-null
         @RawField
@@ -692,6 +705,14 @@ public class JfrTypeRepository implements JfrRepository {
 
     @RawStructure
     private interface ClassLoaderInfoRaw extends JfrTypeInfo {
+        @PinnedObjectField
+        @RawField
+        void setClassLoader(ClassLoader value);
+
+        @PinnedObjectField
+        @RawField
+        ClassLoader getClassLoader();
+
         @RawField
         void setClassTraceId(long value);
 
@@ -775,7 +796,9 @@ public class JfrTypeRepository implements JfrRepository {
             // IDs cannot be compared since they are only assigned after checking the table.
             PackageInfoRaw entry1 = (PackageInfoRaw) v0;
             PackageInfoRaw entry2 = (PackageInfoRaw) v1;
-            return entry1.getNameLength().equal(entry2.getNameLength()) && LibC.memcmp(entry1.getModifiedUTF8Name(), entry2.getModifiedUTF8Name(), entry1.getNameLength()) == 0;
+            return entry1.getModule() == entry2.getModule() &&
+                            entry1.getNameLength().equal(entry2.getNameLength()) &&
+                            LibC.memcmp(entry1.getModifiedUTF8Name(), entry2.getModifiedUTF8Name(), entry1.getNameLength()) == 0;
         }
 
         @Override
@@ -836,6 +859,14 @@ public class JfrTypeRepository implements JfrRepository {
         protected UninterruptibleEntry copyToHeap(UninterruptibleEntry visitedOnStack) {
             return copyToHeap(visitedOnStack, SizeOf.unsigned(ModuleInfoRaw.class));
         }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        protected boolean isEqual(UninterruptibleEntry v0, UninterruptibleEntry v1) {
+            ModuleInfoRaw a = (ModuleInfoRaw) v0;
+            ModuleInfoRaw b = (ModuleInfoRaw) v1;
+            return a.getModule() == b.getModule();
+        }
     }
 
     private final class JfrClassLoaderInfoTable extends JfrTypeInfoTable {
@@ -854,6 +885,14 @@ public class JfrTypeRepository implements JfrRepository {
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
         protected UninterruptibleEntry copyToHeap(UninterruptibleEntry visitedOnStack) {
             return copyToHeap(visitedOnStack, SizeOf.unsigned(ClassLoaderInfoRaw.class));
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        protected boolean isEqual(UninterruptibleEntry v0, UninterruptibleEntry v1) {
+            ClassLoaderInfoRaw a = (ClassLoaderInfoRaw) v0;
+            ClassLoaderInfoRaw b = (ClassLoaderInfoRaw) v1;
+            return a.getClassLoader() == b.getClassLoader();
         }
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
@@ -391,6 +391,7 @@ public class JfrTypeRepository implements JfrRepository {
          * and does not need to be serialized.
          */
         if (packageInfoRaw.getNameLength().equal(0)) {
+            NullableNativeMemory.free(packageInfoRaw.getModifiedUTF8Name());
             return false;
         }
         packageInfoRaw.setHash(getHash(packageInfoRaw));

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
@@ -415,7 +415,11 @@ public class JfrTypeRepository implements JfrRepository {
         }
 
         packageInfoRaw.setId(++currentPackageId);
-        typeInfo.packages.putNew(packageInfoRaw);
+        if (((PackageInfoRaw) typeInfo.packages.putNew(packageInfoRaw)).isNull()) {
+            currentPackageId--;
+            NullableNativeMemory.free(packageInfoRaw.getModifiedUTF8Name());
+            return false;
+        }
         // Do not free the buffer. A pointer to it is shallow copied into the hash map.
         assert typeInfo.packages.contains(packageInfoRaw);
         return true;
@@ -427,10 +431,13 @@ public class JfrTypeRepository implements JfrRepository {
 
     private long getPackageId(PackageInfoRaw packageInfoRaw) {
         if (packageInfoRaw.getModifiedUTF8Name().isNonNull() && packageInfoRaw.getNameLength().aboveOrEqual(1)) {
+            PackageInfoRaw entry;
             if (flushedPackages.contains(packageInfoRaw)) {
-                return ((PackageInfoRaw) flushedPackages.get(packageInfoRaw)).getId();
+                entry = (PackageInfoRaw) flushedPackages.get(packageInfoRaw);
+            } else {
+                entry = (PackageInfoRaw) typeInfo.packages.get(packageInfoRaw);
             }
-            return ((PackageInfoRaw) typeInfo.packages.get(packageInfoRaw)).getId();
+            return entry.isNonNull() ? entry.getId() : 0;
         } else {
             // Empty package has reserved ID 0
             return 0;
@@ -448,7 +455,10 @@ public class JfrTypeRepository implements JfrRepository {
         moduleInfoRaw.setId(++currentModuleId);
         moduleInfoRaw.setHasClassLoader(module.getClassLoader() != null);
         moduleInfoRaw.setClassLoader(module.getClassLoader());
-        typeInfo.modules.putNew(moduleInfoRaw);
+        if (((ModuleInfoRaw) typeInfo.modules.putNew(moduleInfoRaw)).isNull()) {
+            currentModuleId--;
+            return false;
+        }
         return true;
     }
 
@@ -461,10 +471,13 @@ public class JfrTypeRepository implements JfrRepository {
             ModuleInfoRaw moduleInfoRaw = StackValue.get(ModuleInfoRaw.class);
             moduleInfoRaw.setModule(module);
             moduleInfoRaw.setHash(getIdentityHash(module));
+            ModuleInfoRaw entry;
             if (flushedModules.contains(moduleInfoRaw)) {
-                return ((ModuleInfoRaw) flushedModules.get(moduleInfoRaw)).getId();
+                entry = (ModuleInfoRaw) flushedModules.get(moduleInfoRaw);
+            } else {
+                entry = (ModuleInfoRaw) typeInfo.modules.get(moduleInfoRaw);
             }
-            return ((ModuleInfoRaw) typeInfo.modules.get(moduleInfoRaw)).getId();
+            return entry.isNonNull() ? entry.getId() : 0;
         } else {
             return 0;
         }
@@ -493,7 +506,12 @@ public class JfrTypeRepository implements JfrRepository {
             classLoaderInfoRaw.setClassTraceId(JfrTraceId.getTraceId(classLoader.getClass()));
         }
 
-        typeInfo.classLoaders.putNew(classLoaderInfoRaw);
+        if (((ClassLoaderInfoRaw) typeInfo.classLoaders.putNew(classLoaderInfoRaw)).isNull()) {
+            if (classLoader != null) {
+                currentClassLoaderId--;
+            }
+            return false;
+        }
         return true;
     }
 
@@ -508,10 +526,13 @@ public class JfrTypeRepository implements JfrRepository {
         ClassLoaderInfoRaw classLoaderInfoRaw = StackValue.get(ClassLoaderInfoRaw.class);
         classLoaderInfoRaw.setClassLoader(classLoader);
         classLoaderInfoRaw.setHash(getIdentityHash(classLoader));
+        ClassLoaderInfoRaw entry;
         if (flushedClassLoaders.contains(classLoaderInfoRaw)) {
-            return ((ClassLoaderInfoRaw) flushedClassLoaders.get(classLoaderInfoRaw)).getId();
+            entry = (ClassLoaderInfoRaw) flushedClassLoaders.get(classLoaderInfoRaw);
+        } else {
+            entry = (ClassLoaderInfoRaw) typeInfo.classLoaders.get(classLoaderInfoRaw);
         }
-        return ((ClassLoaderInfoRaw) typeInfo.classLoaders.get(classLoaderInfoRaw)).getId();
+        return entry.isNonNull() ? entry.getId() : 0;
     }
 
     private void clearEpochData() {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
@@ -564,7 +564,7 @@ public class JfrTypeRepository implements JfrRepository {
             dot = 0;
         }
 
-        int utf8Length = UninterruptibleUtils.String.modifiedUTF8Length(str, false, dotWithSlash);
+        int utf8Length = UninterruptibleUtils.String.utf8Length(str, false, dotWithSlash);
         Pointer buffer = NullableNativeMemory.malloc(utf8Length, NmtCategory.JFR);
         Pointer bufferEnd = buffer.add(utf8Length);
 
@@ -581,7 +581,7 @@ public class JfrTypeRepository implements JfrRepository {
          * Since we're serializing now, we must do replacements here, instead of the symbol
          * repository.
          */
-        Pointer packageNameEnd = UninterruptibleUtils.String.toModifiedUTF8(str, dot, buffer, bufferEnd, false, dotWithSlash);
+        Pointer packageNameEnd = UninterruptibleUtils.String.toUTF8(str, dot, buffer, bufferEnd, false, dotWithSlash);
         packageInfoRaw.setModifiedUTF8Name(buffer);
 
         UnsignedWord packageNameLength = packageNameEnd.subtract(buffer); // end - start

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
@@ -796,14 +796,22 @@ public class JfrTypeRepository implements JfrRepository {
                     if (!contains(sourceInfo)) {
                         // Put if not already there.
                         PackageInfoRaw destinationInfo = (PackageInfoRaw) putNew(sourceInfo);
+                        if (destinationInfo.isNull()) {
+                            sourceInfo = sourceInfo.getNext();
+                            continue;
+                        }
+                        destinationInfo.setModifiedUTF8Name(Word.nullPointer());
                         // allocate a new buffer.
                         Pointer newUtf8Name = NullableNativeMemory.malloc(sourceInfo.getNameLength(), NmtCategory.JFR);
+                        if (newUtf8Name.isNull()) {
+                            remove(destinationInfo);
+                            sourceInfo = sourceInfo.getNext();
+                            continue;
+                        }
                         // set the buffer ptr.
                         destinationInfo.setModifiedUTF8Name(newUtf8Name);
                         // Copy source buffer contents over to new buffer.
-                        if (newUtf8Name.isNonNull()) {
-                            UnmanagedMemoryUtil.copy(sourceInfo.getModifiedUTF8Name(), newUtf8Name, sourceInfo.getNameLength());
-                        }
+                        UnmanagedMemoryUtil.copy(sourceInfo.getModifiedUTF8Name(), newUtf8Name, sourceInfo.getNameLength());
                     }
                     sourceInfo = sourceInfo.getNext();
                 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/JfrOldObjectRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/JfrOldObjectRepository.java
@@ -122,25 +122,45 @@ public final class JfrOldObjectRepository implements JfrRepository {
         Pointer buffer = UnsafeStackValue.get(OBJECT_DESCRIPTION_MAX_LENGTH);
         Pointer bufferEnd = buffer.add(OBJECT_DESCRIPTION_MAX_LENGTH);
 
-        int prefixLength = UninterruptibleUtils.String.modifiedUTF8Length(prefix, false);
-        int textLength = UninterruptibleUtils.String.modifiedUTF8Length(text, false);
+        int prefixLength = UninterruptibleUtils.String.utf8Length(prefix, false);
         assert prefixLength < OBJECT_DESCRIPTION_MAX_LENGTH - 3;
 
+        Pointer pos = UninterruptibleUtils.String.toUTF8(prefix, buffer, bufferEnd, false);
+        int totalLength = prefixLength;
         boolean tooLong = false;
-        int totalLength = prefixLength + textLength;
-        if (totalLength > OBJECT_DESCRIPTION_MAX_LENGTH) {
-            totalLength = OBJECT_DESCRIPTION_MAX_LENGTH;
-            textLength = OBJECT_DESCRIPTION_MAX_LENGTH - prefixLength - 3;
-            tooLong = true;
+        for (int index = 0; index < text.length(); index++) {
+            char ch = UninterruptibleUtils.String.charAt(text, index);
+            int byteLength = UninterruptibleUtils.String.utf8Length(ch);
+            int charsConsumed = 1;
+            if (Character.isHighSurrogate(ch) && index + 1 < text.length()) {
+                char low = UninterruptibleUtils.String.charAt(text, index + 1);
+                if (Character.isLowSurrogate(low)) {
+                    byteLength = UninterruptibleUtils.String.utf8Length(Character.toCodePoint(ch, low));
+                    charsConsumed = 2;
+                }
+            }
+
+            int remaining = OBJECT_DESCRIPTION_MAX_LENGTH - totalLength;
+            if (remaining < byteLength) {
+                tooLong = true;
+                break;
+            }
+
+            if (charsConsumed == 2) {
+                char low = UninterruptibleUtils.String.charAt(text, index + 1);
+                pos = UninterruptibleUtils.String.writeUTF8(pos, Character.toCodePoint(ch, low));
+                index++;
+            } else {
+                pos = UninterruptibleUtils.String.writeUTF8(pos, ch);
+            }
+            totalLength += byteLength;
         }
 
-        Pointer pos = UninterruptibleUtils.String.toModifiedUTF8(prefix, buffer, bufferEnd, false);
-        pos = UninterruptibleUtils.String.toModifiedUTF8(text, textLength, pos, bufferEnd, false, null);
-
-        if (tooLong) {
+        if (tooLong && totalLength <= OBJECT_DESCRIPTION_MAX_LENGTH - 3) {
             pos.writeByte(0, (byte) '.');
             pos.writeByte(1, (byte) '.');
             pos.writeByte(2, (byte) '.');
+            totalLength += 3;
         }
 
         JfrNativeEventWriter.putString(data, buffer, totalLength);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/JfrOldObjectRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/JfrOldObjectRepository.java
@@ -132,10 +132,10 @@ public final class JfrOldObjectRepository implements JfrRepository {
             char ch = UninterruptibleUtils.String.charAt(text, index);
             int byteLength = UninterruptibleUtils.String.utf8Length(ch);
             int charsConsumed = 1;
-            if (Character.isHighSurrogate(ch) && index + 1 < text.length()) {
+            if (UninterruptibleUtils.String.isHighSurrogate(ch) && index + 1 < text.length()) {
                 char low = UninterruptibleUtils.String.charAt(text, index + 1);
-                if (Character.isLowSurrogate(low)) {
-                    byteLength = UninterruptibleUtils.String.utf8Length(Character.toCodePoint(ch, low));
+                if (UninterruptibleUtils.String.isLowSurrogate(low)) {
+                    byteLength = UninterruptibleUtils.String.utf8Length(UninterruptibleUtils.String.toCodePoint(ch, low));
                     charsConsumed = 2;
                 }
             }
@@ -148,7 +148,7 @@ public final class JfrOldObjectRepository implements JfrRepository {
 
             if (charsConsumed == 2) {
                 char low = UninterruptibleUtils.String.charAt(text, index + 1);
-                pos = UninterruptibleUtils.String.writeUTF8(pos, Character.toCodePoint(ch, low));
+                pos = UninterruptibleUtils.String.writeUTF8(pos, UninterruptibleUtils.String.toCodePoint(ch, low));
                 index++;
             } else {
                 pos = UninterruptibleUtils.String.writeUTF8(pos, ch);

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestEmergencyDump.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestEmergencyDump.java
@@ -51,8 +51,8 @@ public class TestEmergencyDump extends JfrRecordingTest {
     public void test() throws Throwable {
         List<String> expectedStrings = new ArrayList<>();
         expectedStrings.add("first");
-        expectedStrings.add("second");
-        expectedStrings.add("third");
+        expectedStrings.add("second\0nul");
+        expectedStrings.add("third \uD83D\uDE80");
 
         String[] testedEvents = new String[]{"com.jfr.String"};
         Recording recording = startRecording(testedEvents);

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestGrowableWordArrayQuickSort.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestGrowableWordArrayQuickSort.java
@@ -46,21 +46,25 @@ public class TestGrowableWordArrayQuickSort {
         RandomGenerator randomGenerator = RandomGenerator.getDefault();
         GrowableWordArray gwa = StackValue.get(GrowableWordArray.class);
         GrowableWordArrayAccess.initialize(gwa);
-        long nextLong = 0;
-        for (int i = 0; i < 1000; i++) {
-            // Occasionally insert duplicates
-            if (i % 50 != 0) {
-                nextLong = randomGenerator.nextLong();
+        try {
+            long nextLong = 0;
+            for (int i = 0; i < 1000; i++) {
+                // Occasionally insert duplicates
+                if (i % 50 != 0) {
+                    nextLong = randomGenerator.nextLong();
+                }
+                GrowableWordArrayAccess.add(gwa, WordFactory.signed(nextLong), NmtCategory.JFR);
             }
-            GrowableWordArrayAccess.add(gwa, WordFactory.signed(nextLong), NmtCategory.JFR);
-        }
 
-        GrowableWordArrayAccess.qsort(gwa, 0, gwa.getSize() - 1, TestGrowableWordArrayQuickSort::compare);
-        long last = GrowableWordArrayAccess.get(gwa, 0).rawValue();
-        for (int i = 0; i < gwa.getSize(); i++) {
-            long current = GrowableWordArrayAccess.get(gwa, i).rawValue();
-            assertTrue(last <= current);
-            last = current;
+            GrowableWordArrayAccess.qsort(gwa, 0, gwa.getSize() - 1, TestGrowableWordArrayQuickSort::compare);
+            long last = GrowableWordArrayAccess.get(gwa, 0).rawValue();
+            for (int i = 0; i < gwa.getSize(); i++) {
+                long current = GrowableWordArrayAccess.get(gwa, i).rawValue();
+                assertTrue(last <= current);
+                last = current;
+            }
+        } finally {
+            GrowableWordArrayAccess.freeData(gwa);
         }
     }
 

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestJfrSymbolRepository.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestJfrSymbolRepository.java
@@ -52,8 +52,14 @@ public class TestJfrSymbolRepository extends JfrRecordingTest {
         long id1 = getSymbolId(repo, str1);
         long id2 = getSymbolId(repo, str2);
         long id1copy = getSymbolId(repo, str1copy);
+        long empty1 = getSymbolId(repo, "");
+        long empty2 = getSymbolId(repo, "");
+        long nullId = getSymbolId(repo, null);
         assertEquals(id1, id1copy);
         assertNotEquals(id1, id2);
+        assertNotEquals(0, empty1);
+        assertEquals(empty1, empty2);
+        assertEquals(0, nullId);
     }
 
     @Uninterruptible(reason = "Needed for JfrSymbolRepository.getSymbolId().")


### PR DESCRIPTION
Stacked on top of oracle/graal#11530.

This branch carries the review follow-ups and additional correctness fixes discussed for the emergency-dump work, split into separate commits so they can be reviewed or cherry-picked individually.

Highlights:
- emergency-dump repository/file handling fixes
- path-length and fallback cleanup
- symbol/type repository correctness fixes
- real UTF-8 encoding for JFR string payloads
- synchronization for JFR class-id registration
- safer handling of metadata-table allocation failures

If you prefer, these commits can also be squashed before merging into the contributor branch.